### PR TITLE
Updated script to deploy secrets

### DIFF
--- a/site/profiles/files/secrets.sh
+++ b/site/profiles/files/secrets.sh
@@ -2,59 +2,82 @@
 # Pulls secrets from a private repository and merges them into the Hiera tree
 
 SECRETS=$1
+TEMPDIR="/tmp/secrets-$(date +%s)"
+OUTPUT_LABEL='deploy-secrets'
+
+# Purely cosmetic function to prettify output
+# Set OUTPUT_LABEL to change the label
+# Supports ERROR, SUCCESS, and WARN as arguments
+function output() {
+  local label=${OUTPUT_LABEL:-$0}
+  local timestamp=$(date +%d/%m/%Y\ %H:%M)
+  local colour='\033[34m' # Blue
+  local reset='\033[0m'
+  case $1 in
+      ERROR) local colour='\033[31m' ;; # Red
+    SUCCESS) local colour='\033[32m' ;; # Green
+       WARN) local colour='\033[33m' ;; # Yellow
+  esac
+  while read line; do
+    echo -e "${colour}${label} [${timestamp}]${reset} ${line}"
+  done
+}
 
 # Check user is root
-if [ $(id -u) != 0 ]; then
-  echo "You must run this script as root!"
-  exit 1
-fi
+[ $(id -u) != 0 ] && echo "ERROR - You must run this script as root!" | output ERROR && exit 1
 
 # Check that a repo has been specified
-if [ -z "$1" ]; then
-  echo "You must specify a secrets repo"
-  exit 1
-fi
+[ -z "$SECRETS" ] && echo "ERROR - You must specify a secrets repository!" | output ERROR && exit 1
 
+# Make sure we actually have Puppet environments set up
+#[ ! -d /etc/puppet/environments ] && echo "/etc/puppet/environments does not exist!" | output ERROR && exit 1
 
-# for each subdirectory of 'environments'....
-for environment in /etc/puppet/environments/* ; do
+echo "Deploying secrets from ${SECRETS}" | output
+git clone ${SECRETS} ${TEMPDIR} 2>&1 | output
 
-  e=`basename $environment`
+for environment in ./etc/puppet/environments/*; do
+  envname=$(basename ${environment})
 
-  echo "Environment is $e"
-
-  #check if secrest folder exists....
-  echo "checking to see if $environment/secrets  exists..."
-  if [  -d "${environment}/secrets" ]; then
-
-    # delete the directory if it does...
-    echo "...yup cleaning up old ${environment}/secrets"
-    rm -rf ${environment}/secrets
-  fi
-
-  #re-create the secrets directory
-  echo "creating new ${environment}/secrets dir"
-  mkdir ${environment}/secrets
-
-  #clone the secrets repo to the secrets folder
-  echo "cloning the secrets repo"
-  #cd ${environment}/secrets
-  git -C ${environment}/secrets clone ${SECRETS}
-
-  #check to see if branch exists in secrets for this environment
-  echo "checking to see if a secrets brach exists for this environment"
-  if [ -n `git -C ${environment}/secrets/puppet-secrets branch --list $e` ]; then
-
-    #check out environment branch
-    echo "checking out the secret repo branch for $e"
-    git -C ${environment}/secrets/puppet-secrets checkout $e
-
-    #move the secrets to the environment's 'hiera' folder
-    mv -f ${environment}/secrets/puppet-secrets/* ${environment}/hiera/
+  # Clean up old secrets directory or create new one
+  if [ -d "${environment}/secrets" ]; then
+    echo "Purging secrets from ${envname}" | output
+    rm -rf ${environment}/secrets/*
   else
-   echo "no secrets brach exists for $e"
+    mkdir ${environment}/secrets
   fi
 
-  #clean up
-  rm -rf ${environment}/secrets/
+  # Check to see if branch exists in secrets repository that matches environment
+  if [[ -n $(git -C ${TEMPDIR} branch --list ${envname}) ]]; then
+    # Check out environment branch
+    git -C ${TEMPDIR} checkout ${envname} 2>&1 >/dev/null | output
+    # Deploy new secrets
+    cp -R ${TEMPDIR}/* ${environment}/secrets/
+    if [ $? == '0' ]; then
+      echo "New secrets deployed to ${envname}" | output
+    else
+      echo "ERROR - Unable to deploy secrets from ${TEMPDIR} to ${environment}" | output ERROR
+      SOFTFAIL+=("${envname}")
+      break # Skip to next environment
+    fi
+  else
+    echo "No secrets available for ${envname}" | output
+  fi
+
 done
+
+
+# This is a little hacky but provides good visibilty of failures
+if [ ! -z $SOFTFAIL ]; then
+  echo "ERROR - Did not successfully complete deployment!" | output ERROR
+  failures=$(printf ", %s" "${SOFTFAIL[@]}"); failures=${failures:1}
+  echo "Failed to deploy to:${failures}" | output ERROR
+  exit 1;
+else
+  # We only want to clean up if we exit cleanly, to aid debugging on fail
+  echo "Removing temporary directory at ${TEMPDIR}" | output
+  rm -rf ${TEMPDIR} 2>&1 >/dev/null
+
+  # :wq
+  echo "Deployment completed successfully!" | output SUCCESS
+  exit 0
+fi


### PR DESCRIPTION
I've *improved* the secrets deployment script to provide better visibility of what is going on and better error handling.

The script now has the following changes/features:
- Colourised output
- Secrets repository is only cloned once to a temporary location
- Output when there is a failure reports which environments failed to deploy correctly

![secrets](https://cloud.githubusercontent.com/assets/5775911/6258863/4405bbf2-b7c4-11e4-92f0-d054bc596b5c.png)
