### PR TITLE
Fixed environment path in secrets deployment script

### DIFF
--- a/site/profiles/files/secrets.sh
+++ b/site/profiles/files/secrets.sh
@@ -48,9 +48,8 @@ for environment in /etc/puppet/environments/*; do
   fi
 
   # Check to see if branch exists in secrets repository that matches environment
-  if [[ -n $(git -C ${TEMPDIR} branch --list ${envname}) ]]; then
-    # Check out environment branch
-    git -C ${TEMPDIR} checkout ${envname} 2>&1 >/dev/null | output
+  git -C ${TEMPDIR} checkout ${envname} >/dev/null 2>&1
+  if [[ $? == '0' ]]; then
     # Deploy new secrets
     cp -R ${TEMPDIR}/* ${environment}/${HIERA_PATH}
     if [ $? == '0' ]; then

--- a/site/profiles/files/secrets.sh
+++ b/site/profiles/files/secrets.sh
@@ -3,6 +3,7 @@
 
 SECRETS=$1
 TEMPDIR="/tmp/secrets-$(date +%s)"
+HIERA_PATH="hiera/secrets"
 OUTPUT_LABEL='deploy-secrets'
 
 # Purely cosmetic function to prettify output
@@ -30,20 +31,20 @@ function output() {
 [ -z "$SECRETS" ] && echo "ERROR - You must specify a secrets repository!" | output ERROR && exit 1
 
 # Make sure we actually have Puppet environments set up
-#[ ! -d /etc/puppet/environments ] && echo "/etc/puppet/environments does not exist!" | output ERROR && exit 1
+[ ! -d /etc/puppet/environments ] && echo "/etc/puppet/environments does not exist!" | output ERROR && exit 1
 
 echo "Deploying secrets from ${SECRETS}" | output
 git clone ${SECRETS} ${TEMPDIR} 2>&1 | output
 
-for environment in ./etc/puppet/environments/*; do
+for environment in /etc/puppet/environments/*; do
   envname=$(basename ${environment})
 
   # Clean up old secrets directory or create new one
-  if [ -d "${environment}/secrets" ]; then
-    echo "Purging secrets from ${envname}" | output
-    rm -rf ${environment}/secrets/*
+  if [ -d "${environment}/${HIERA_PATH}" ]; then
+    echo "Purging previous secrets from ${envname}" | output
+    rm -rf ${environment}/${HIERA_PATH}/*
   else
-    mkdir ${environment}/secrets
+    mkdir ${environment}/${HIERA_PATH}
   fi
 
   # Check to see if branch exists in secrets repository that matches environment
@@ -51,7 +52,7 @@ for environment in ./etc/puppet/environments/*; do
     # Check out environment branch
     git -C ${TEMPDIR} checkout ${envname} 2>&1 >/dev/null | output
     # Deploy new secrets
-    cp -R ${TEMPDIR}/* ${environment}/secrets/
+    cp -R ${TEMPDIR}/* ${environment}/${HIERA_PATH}
     if [ $? == '0' ]; then
       echo "New secrets deployed to ${envname}" | output
     else
@@ -60,7 +61,7 @@ for environment in ./etc/puppet/environments/*; do
       break # Skip to next environment
     fi
   else
-    echo "No secrets available for ${envname}" | output
+    echo "No secrets available for ${envname}" | output WARN
   fi
 
 done


### PR DESCRIPTION
I've fixed the output path as we weren't deploying to `$ENVIRONMENT/hiera/secrets` but incorrectly to `$ENVIRONMENT/secrets` instead.

Output will now also produce warnings for environments without secrets.

Works on my Fedora 21 build as well as on Ubuntu 14.04 LTS. Can you test this works before merging?

![selection_004](https://cloud.githubusercontent.com/assets/5775911/6275632/adb96472-b878-11e4-870c-02a1ce566e68.png)
