### PR TITLE
Added minimal nginx configuration

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 # Third-party modules
+mod 'jfryman/nginx',          '0.2.2'
 mod 'mthibaut/users',         '1.0.11'
 mod 'puppetlabs/firewall',    '1.3.0'
 mod 'puppetlabs/ntp',         '3.3.0'

--- a/site/profiles/manifests/nginx.pp
+++ b/site/profiles/manifests/nginx.pp
@@ -1,0 +1,19 @@
+# Class profiles::nginx
+# This class will configure Nginx
+#
+# Parameters:
+#
+# Requires:
+# - jfryman/nginx
+#
+# Sample Usage:
+#   class { 'profiles::nginx': }
+#
+class profiles::nginx (
+
+) {
+
+  include ::nginx
+
+}
+

--- a/site/profiles/tests/nginx.pp
+++ b/site/profiles/tests/nginx.pp
@@ -1,0 +1,1 @@
+include ::profiles::nginx


### PR DESCRIPTION
Absolutely empty Nginx module. The reason for this is to make adding additional configuration easy later on such as monitoring and firewall rules.