### PR TITLE
CentOS/RHEL support for MongoDB/PostgreSQL/RabbitMQ

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 # Third-party modules
+mod 'ajcrowe/supervisord',    '0.5.2'
 mod 'jfryman/nginx',          '0.2.2'
 mod 'mthibaut/users',         '1.0.11'
 mod 'puppetlabs/firewall',    '1.3.0'
@@ -18,6 +19,7 @@ mod 'zack/r10k',              '2.6.2'
 # Dependency modules
 mod 'croddy/make',            '0.0.5'
 mod 'darin/zypprepo',         '1.0.2'
+mod 'garethr/erlang',         '0.3.0'
 mod 'gentoo/portage',         '2.2.0'
 mod 'puppetlabs/apache',      '1.3.0'
 mod 'puppetlabs/apt',         '1.7.0'
@@ -30,4 +32,5 @@ mod 'puppetlabs/pe_gem',      '0.1.0'
 mod 'puppetlabs/ruby',        '0.4.0'
 mod 'puppetlabs/stdlib',      '4.5.1'
 mod 'puppetlabs/vcsrepo',     '1.2.0'
+mod 'stahnma/epel',           '1.0.2'
 mod 'nanliu/staging',         '1.0.3'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,10 +1,21 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
+    ajcrowe-supervisord (0.5.2)
+      puppetlabs-concat (< 2.0.0, >= 1.0.0)
+      puppetlabs-stdlib (>= 4.4.0)
     croddy-make (0.0.5)
     darin-zypprepo (1.0.2)
+    garethr-erlang (0.3.0)
+      puppetlabs-apt (>= 0)
+      puppetlabs-stdlib (>= 0)
+      stahnma-epel (>= 0)
     gentoo-portage (2.2.0)
       puppetlabs-concat (~> 1.0)
+    jfryman-nginx (0.2.2)
+      puppetlabs-apt (< 2.0.0, >= 1.0.0)
+      puppetlabs-concat (< 2.0.0, >= 1.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
     mthibaut-users (1.0.11)
       puppetlabs-stdlib (>= 0)
     nanliu-staging (1.0.3)
@@ -54,6 +65,7 @@ FORGE
       puppetlabs-stdlib (>= 2.3.0)
     spuder-gitlab (2.3.5)
       puppetlabs-stdlib (>= 3.0.0)
+    stahnma-epel (1.0.2)
     stephenrjohnson-puppet (1.3.1)
       puppetlabs-apache (>= 1.0.1)
       puppetlabs-apt (>= 1.1.0)
@@ -72,10 +84,14 @@ FORGE
       puppetlabs-vcsrepo (>= 0.1.2)
 
 DEPENDENCIES
+  ajcrowe-supervisord (= 0.5.2)
   croddy-make (= 0.0.5)
   darin-zypprepo (= 1.0.2)
+  garethr-erlang (= 0.3.0)
   gentoo-portage (= 2.2.0)
+  jfryman-nginx (= 0.2.2)
   mthibaut-users (= 1.0.11)
+  nanliu-staging (= 1.0.3)
   puppetlabs-apache (= 1.3.0)
   puppetlabs-apt (= 1.7.0)
   puppetlabs-concat (= 1.2.0)
@@ -96,5 +112,7 @@ DEPENDENCIES
   rtyler-jenkins (= 1.3.0)
   saz-sudo (= 3.0.9)
   spuder-gitlab (= 2.3.5)
+  stahnma-epel (= 1.0.2)
   stephenrjohnson-puppet (= 1.3.1)
   zack-r10k (= 2.6.2)
+

--- a/site/profiles/manifests/appserver.pp
+++ b/site/profiles/manifests/appserver.pp
@@ -1,0 +1,23 @@
+# Class profiles::appserver
+#
+# This class will manage application server installations
+#
+# Parameters:
+#  ['port']     - Port which MongoDB should listen on. Defaults = 27018
+#
+# Requires:
+# - ajcrowe/supervisord
+# - puppetlabs/stdlib
+#
+# Sample Usage:
+#   class { 'profiles::appserver': }
+#
+class profiles::appserver(
+
+){
+
+  class { 'supervisord':
+    inet_server => true
+  }
+
+}

--- a/site/profiles/manifests/appserver.pp
+++ b/site/profiles/manifests/appserver.pp
@@ -17,7 +17,8 @@ class profiles::appserver(
 ){
 
   class { 'supervisord':
-    inet_server => true
+    inet_server => true,
+    install_pip => true
   }
 
 }

--- a/site/profiles/manifests/postgresql.pp
+++ b/site/profiles/manifests/postgresql.pp
@@ -43,7 +43,7 @@ class profiles::postgresql(
     version             => $version,
     datadir             => "${dbroot}/data",
     confdir             => $dbroot,
-    #needs_initdb        => true,
+    needs_initdb        => true,
     service_name        => 'postgresql', # confirm on ubuntu
     require             => File[$dbroot]
   } ->

--- a/site/profiles/manifests/postgresql.pp
+++ b/site/profiles/manifests/postgresql.pp
@@ -41,10 +41,10 @@ class profiles::postgresql(
   class { 'postgresql::globals':
     manage_package_repo => true,
     version             => $version,
-    encoding            => 'UTF8',
-    locale              => 'en_GB',
     datadir             => "${dbroot}/data",
     confdir             => $dbroot,
+    #needs_initdb        => true,
+    service_name        => 'postgresql', # confirm on ubuntu
     require             => File[$dbroot]
   } ->
 

--- a/site/profiles/manifests/rabbitmq.pp
+++ b/site/profiles/manifests/rabbitmq.pp
@@ -3,13 +3,16 @@
 # This class will manage rabbitmq installations
 #
 # Parameters:
+#  ['port']    - Port which RabbitMQ should listen on. Defaults = 5672
+#  ['version'] - Version of RabbitMQ to install. Default = 3.4.4
 #
 # Requires:
 # - puppetlabs/rabbitmq
+# - garethr/erlang
 #
 # Sample Usage:
 #   class { 'profiles::rabbitmq':
-#     ????? => ?????
+#     version => '3.4.4'
 #   }
 #
 class profiles::rabbitmq(
@@ -19,9 +22,21 @@ class profiles::rabbitmq(
 
 ){
 
+  # Red Hat uses weird version numbers
+  if $::osfamily == 'RedHat' {
+    $ver = "${version}-1"
+    class { 'erlang': epel_enable => true }
+  } else {
+    $ver = $version
+    package { 'erlang-base': ensure => 'latest' }
+  }
+
+  include ::erlang
+
   class { '::rabbitmq':
-    version => $version,
+    version => $ver,
     port    => $port,
+    require => Class[erlang]
   }
 
 }


### PR DESCRIPTION
I've added support for the Red Hat family to the MongoDB, PostgreSQL, and RabbitMQ profiles.

In the case of MongoDB this unfortunately meant the removal of the custom directory structure for now. I'm confident that it could be made to work but due to time constraints I felt it was more important to add this support and go back to the custom directory configuration later if so desired.

I've  not yet entirely 'fixed' the PostgreSQL module either. Currently running `initdb -D /postgres/data` as the `postgres` user is required in order to start the service correctly. Will make a point to review in due course.