### PR TITLE
Removing working directory directive because it breaks build for some. A...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,11 +11,11 @@ Vagrant.configure(2) do |config|
   end
   
   config.vm.box = "landregistry/centos"
+  config.vm.box_version = "0.1.0"
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "manifests"
     puppet.manifest_file = "site.pp"
     puppet.hiera_config_path = "hiera.vagrant.yaml"
-    puppet.working_directory = "/tmp/vagrant-puppet"
     puppet.options = '--environment=development'
     puppet.module_path = ["site", "modules"]
     puppet.facter = {


### PR DESCRIPTION
...lso adding box version
Nothing major just a couple of changes to vagrant file.  The Puppet working directory directive was causing builds to fail for some.  No harm in removing it.  Also Wanted to control what version of vagrant box the build is using.  So added line to tie it down.  Currently landregistry/centos 0.1.0.