### PR TITLE
Feature vagrant librarian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .librarian/
 .tmp/
-modules/
 Vagrantfile
 .vagrant

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
-forge 'https://forgeapi.puppetlabs.com'
+forge 'https://forge.puppetlabs.com'
 
 # Third-party modules
 mod 'ajcrowe/supervisord',             '0.5.2'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,9 @@ Vagrant.configure(2) do |config|
     puts "You may have to run `librarian-puppet` on your host machine if you have not already"
   end
   
+  config.librarian_puppet.puppetfile_dir = "."
+  config.librarian_puppet.placeholder_filename = ".PLACEHOLDER"  
+ 
   config.vm.box = "landregistry/centos"
   config.vm.box_version = "0.1.0"
   config.vm.provision :puppet do |puppet|


### PR DESCRIPTION
Just making the vagrant experience a little less involved.  This was raised as a reason why charges did not want to use the vagrant env we provided.

The changes involved were to get the plugin "vagrant librarian_puppet" to work.  It's a bit behind the curve in terms of it does not work with puppetlabs forgeapi (redirects not supported).  Also it requires that the modules directory exists.