### PR TITLE
Feature vagrant librarian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .tmp/
 Vagrantfile
 .vagrant
+modules/*
+!modules/.PLACEHOLDER

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .librarian/
 .tmp/
-modules/
 Vagrantfile
 .vagrant

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
-forge 'https://forgeapi.puppetlabs.com'
+forge 'https://forge.puppetlabs.com'
 
 # Third-party modules
 mod 'ajcrowe/supervisord',             '0.5.2'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,9 @@ Vagrant.configure(2) do |config|
     puts "You may have to run `librarian-puppet` on your host machine if you have not already"
   end
   
+  config.librarian_puppet.puppetfile_dir = "."
+  config.librarian_puppet.placeholder_filename = ".PLACEHOLDER"  
+ 
   config.vm.box = "landregistry/centos"
   config.vm.box_version = "0.1.0"
   config.vm.provision :puppet do |puppet|


### PR DESCRIPTION
Here I am making the vagrant environment a little more user friendly.  We're using the vagrant plugin "vagrant_librarian_puppet" to fetch the modules before vagrant provisions the machine.  The plugin is not compatible with the puppetlabs forge api so this had to reverted to the forge url.  I also had to put a pattern in to include a dummy file but also exclude the directory modules in the git ignore file.  This is because the plugin requires the directory to exist.