### PR TITLE
Feature test logging config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ Vagrantfile
 modules/*
 !modules/.PLACEHOLDER
 
+hiera/vagrant-repository.yaml
+hiera/vagrant-broker.yaml
 hiera/vagrant.yaml
+
 Puppetfile.lock

--- a/site/profiles/manifests/log_forwarder.pp
+++ b/site/profiles/manifests/log_forwarder.pp
@@ -17,7 +17,12 @@ class profiles::log_forwarder{
   }
 
   if $serverenv == 'test' {
-    $servertype = 'repository'
+    $test_zone = split( $::domain, '[.]' )
+    case $test_zone[0]{
+      zone1:      { $servertype = 'repository' }
+      zone2:      { $servertype = 'broker' }
+      default: { fail("No Valid Zone Available - ${::domain}") }
+    }
   } else {
     case $ip_first_octet[0]{
       10:      { $servertype = 'broker' }


### PR DESCRIPTION
This is to add support to log_forwarder.pp to check if the broker or repository config needs applying.  $::ipaddress can’t be used for a vagrant images, as every vagrant image IP starts with a 10. instead we’ve specified the zone on the domain name.