### PR TITLE
Prevent puppet fail if db or user hash not present & amend db names

### DIFF
--- a/hiera/roles/digital-register-data.yaml
+++ b/hiera/roles/digital-register-data.yaml
@@ -5,11 +5,11 @@ classes:
 
 postgres_databases:
   registerdata:
-    user: registerdata
+    user: register_data
     password: md5b84f21541ef11f3e5d07840ed6f98cd9
     owner: registerdata
   userdata:
-    user: userdata
+    user: user_data
     password: md5f9c9ad05de8e8127913a9149dd64959c
     owner: userdata
 

--- a/site/profiles/manifests/postgresql.pp
+++ b/site/profiles/manifests/postgresql.pp
@@ -42,10 +42,13 @@
 
 class profiles::postgresql(
 
-  $port     = 5432,
-  $version  = '9.3',
-  $remote   = true,
-  $dbroot   = '/postgres',
+  $port        = 5432,
+  $version     = '9.3',
+  $remote      = true,
+  $dbroot      = '/postgres',
+  $databases   = hiera_hash('postgres_databases',false),
+  $users       = hiera_hash('postgres_users', false),
+  $pg_hba_rule = hiera_hash('pg_hba_rule', false)
 
 ){
 
@@ -119,15 +122,21 @@ class profiles::postgresql(
   include postgresql::server::contrib
   #include postgresql::server::postgis
 
-
   package{ 'postgis2_93' :
-    ensure   => installed,
+    ensure => installed,
   }
 
   include postgresql::lib::devel
-  create_resources('postgresql::server::db', hiera_hash('postgres_databases'))
-  create_resources('postgresql::server::role', hiera_hash('postgres_users'))
+
+  if $databases {
+    create_resources('postgresql::server::db', $databases)
+  }
+  if $users {
+    create_resources('postgresql::server::role', $users)
+  }
   #Will allow hba rules to be set for specific users/dbs via hiera
-  #create_resources('postgresql::server::pg_hba_rule', hiera_hash('pg_hba_rule'))
+  if $pg_hba_rule {
+    create_resources('postgresql::server::pg_hba_rule', $pg_hba_rule)
+  }
 
 }


### PR DESCRIPTION
Updated Data base names to match those in higher level environments.

Additionally amended postgres module to enable installation and configuration of postgres with out data basses defined in hiera.

 