### PR TITLE
Changed default db user names

### DIFF
--- a/hiera/roles/digital-register-data.yaml
+++ b/hiera/roles/digital-register-data.yaml
@@ -7,11 +7,11 @@ postgres_databases:
   registerdata:
     user: register_data
     password: md5b84f21541ef11f3e5d07840ed6f98cd9
-    owner: registerdata
+    owner: register_data
   userdata:
     user: user_data
     password: md5f9c9ad05de8e8127913a9149dd64959c
-    owner: userdata
+    owner: user_data
 
 postgres_users:
   deployment:


### PR DESCRIPTION
The puppet run on digital register data was failing following the renaming of the databases - this change should correct the issue