### PR TITLE
Fix error generated by SE Linux test

### DIFF
--- a/site/profiles/manifests/puppet/master.pp
+++ b/site/profiles/manifests/puppet/master.pp
@@ -21,7 +21,7 @@ class profiles::puppet::master (
 
   $control_repo = 'https://github.com/LandRegistry-Ops/puppet-control.git',
   $hiera_path   = '/etc/puppet/hiera.yaml',
-  $environment = 'production',
+  $environment = hiera('$::profiles::puppet::environment', 'production'),
   $arguments   = '--no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
   $run_hours   = '08-16',
   $run_days    = '1-5'
@@ -29,7 +29,7 @@ class profiles::puppet::master (
   ){
 
     # Install nginx
-    include ::nginx
+    include ::profiles::nginx
 
     # Install puppet-server package
     package { 'puppet-server' :


### PR DESCRIPTION
The puppetmaster SE Linux policy dose not include 'allow httpd_t self:process setrlimit'. This resulted in a 'denied' message appearing in the audit log. This change corrects this issue by also loading the Nginx SE Linux policy.