### PR TITLE
Ensure epel is available

### DIFF
--- a/site/profiles/manifests/postgresql.pp
+++ b/site/profiles/manifests/postgresql.pp
@@ -114,6 +114,9 @@ class profiles::postgresql(
       force  => true,
       before => Class[Postgresql::Server]
     }
+    package { 'epel-release' :
+      ensure => installed
+    }
   }
 
 
@@ -123,7 +126,8 @@ class profiles::postgresql(
   #include postgresql::server::postgis
 
   package{ 'postgis2_93' :
-    ensure => installed,
+    ensure  => installed,
+    require => Package['epel-release']
   }
 
   include postgresql::lib::devel


### PR DESCRIPTION
Currently epel is not available by default in our vmware templates and aws amis. This fix ensures that epel is available to enable installation of postgis (which has dependencies in epel).

NB this should only be considered as a temporary fix until we have proper repository management in place. 