### PR TITLE
Fix duplicate package declaration error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,9 +12,9 @@ Vagrant.configure(2) do |config|
 
   config.librarian_puppet.puppetfile_dir = "."
   config.librarian_puppet.placeholder_filename = ".PLACEHOLDER"
-  
+
   config.vm.box = "landregistry/centos"
-  config.vm.box_version = "0.1.0"
+  config.vm.box_version = "0.1.1"
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "manifests"
     puppet.manifest_file = "site.pp"
@@ -43,5 +43,5 @@ Vagrant.configure(2) do |config|
       v.customize ['modifyvm', :id, '--memory', '2048']
     end
   end
-  
+
 end

--- a/site/profiles/manifests/vagrant.pp
+++ b/site/profiles/manifests/vagrant.pp
@@ -29,7 +29,7 @@ class profiles::vagrant{
         'python-devel','ruby','rubygems','autoconf','automake',
         'binutils','bison','flex','gcc','gcc-c++','gettext','libtool',
         'make','patch','pkgconfig','redhat-rpm-config','rpm-build',
-        'rpm-sign','epel-release','libxml2','libxslt','libxml2-devel','wget',
+        'rpm-sign','libxml2','libxslt','libxml2-devel','wget',
         'psmisc','rabbitmq-server']
       $PYTHON='lr-python3-3.4.3-1.x86_64'
       $PYPGK="${PYTHON}.rpm"


### PR DESCRIPTION
This change addresses a duplicate package declaration issue in puppet. Both the Vagrant and postgres profiles had been attempting to declare the package. This change removes the package declaration from the Vagrant profile and bumps the LR CentOS template version to 0.1.1