### PR TITLE
Fix r10k failure to install puppet dependencies

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,7 +12,7 @@ mod 'evenup/redis',                    '1.3.1'
 mod 'ispavailability/file_concat',     '0.2.1'
 mod 'jfryman/nginx',                   '0.2.2'
 mod 'jfryman/selinux',                 '0.2.3'
-mod 'LandRegistry-Ops/puppet-wsgi',    :git => 'https://github.com/LandRegistry-Ops/puppet-wsgi.git',
+mod 'puppet-wsgi',                     :git => 'https://github.com/LandRegistry-Ops/puppet-wsgi.git',
                                        :ref => 'b68704c73631d1dc3960c2200dec6d235613e667'
 mod 'leinaddm/htpasswd',               '0.0.3'
 mod 'maestrodev/wget',                 '1.5.7'


### PR DESCRIPTION
R10k was failing to download puppet dependencies - with the following error:

Module name (Landregistry-Ops/puppet-wsgi) must match either 'modulename' or 'owner/modulename'

This change addresses this issue by removing the 'owner' portion of the module name. The error was not caught prior to commit as the puppet file was tested  with 'librarian-puppet' which did not throw this error. In future the syntax of puppet files should be checked by running:

```$ r10k puppetfile check```