### PR TITLE
Feature jenkins config

### DIFF
--- a/hiera/roles/jenkins-master.yaml
+++ b/hiera/roles/jenkins-master.yaml
@@ -26,3 +26,7 @@ profiles::jenkins::plugins:
     version: 1.54
   mapdb-api:
     version: latest
+  rbenv:
+    version: latest
+  ansicolor:
+    version: latest  

--- a/site/profiles/files/deploy.sh
+++ b/site/profiles/files/deploy.sh
@@ -29,25 +29,25 @@ done
 #[ $(id -u) != 0 ] && echo "ERROR - You must run this script as root!" | output ERROR && exit 1
 
 for PUPPET in ${PUPPETMASTER} ; do
-  
+
   # Copy artifact to puppet master
   echo "Attempting to copy ${ARTIFACT} to ${PUPPET}" | output
-  scp ${DIR}/artifacts/${ARTIFACT} deployment@${PUPPET}:/tmp/ > /dev/null 2>&1
+  scp -o StrictHostKeyChecking=no ${DIR}/artifacts/${ARTIFACT} deployment@${PUPPET}:/tmp/ > /dev/null 2>&1
   if [[ $? == '0' ]]; then
     echo "${ARTIFACT}" successfully copied to ${PUPPET} | output SUCCESS
   else
     echo "Error copying ${ARTIFACT} to ${PUPPET}" | output ERROR && exit 1
   fi
-  
+
   # SSH to puppet master, stop puppetmaster service, purge existing environments,
-  # uncompress artifact and restart puppetmaster service 
-  ssh deployment@${PUPPET} "sudo systemctl stop puppetmaster-unicorn.service" > /dev/null 2>&1
-  [[ $? != '0' ]] && echo "Error stopping puppetmaster service on ${PUPPET}" | output ERROR && exit 1   
+  # uncompress artifact and restart puppetmaster service
+  ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo systemctl stop puppetmaster-unicorn.service" > /dev/null 2>&1
+  [[ $? != '0' ]] && echo "Error stopping puppetmaster service on ${PUPPET}" | output ERROR && exit 1
   ssh deployment@${PUPPET} "sudo rm -rf /etc/puppet/environments" #> /dev/null 2>&1
   [[ $? != '0' ]] && echo "Error purging existing environments on  ${PUPPET}" | output ERROR && exit 1
-  ssh deployment@${PUPPET} "sudo tar -C /etc/puppet/ -xzf /tmp/${ARTIFACT}" > /dev/null 2>&1 
+  ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo tar -C /etc/puppet/ -xzf /tmp/${ARTIFACT}" > /dev/null 2>&1
   [[ $? != '0' ]] && echo "Error extracting artifact on  ${PUPPET}" | output ERROR && exit 1
-  ssh deployment@${PUPPET} "sudo systemctl start puppetmaster-unicorn.service" > /dev/null 2>&1
+  ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo systemctl start puppetmaster-unicorn.service" > /dev/null 2>&1
   if [[ $? == '0' ]]; then
     echo "Puppet environment code and dependencies successfully deployed" | output SUCCESS
   else
@@ -58,7 +58,7 @@ done
 # Copy artifact to remote ci server
 for CI in ${REMOTECI} ; do
   echo "Attempting to copy ${ARTIFACT} to ${CI}" | output
-  scp ${DIR}/artifacts/${ARTIFACT} deployment@${CI}:${DIR}/artifacts/ > /dev/null 2>&1
+  scp -o StrictHostKeyChecking=no ${DIR}/artifacts/${ARTIFACT} deployment@${CI}:${DIR}/artifacts/ > /dev/null 2>&1
   if [[ $? == '0' ]]; then
     echo "${ARTIFACT}" successfully copied to ${CI} | output SUCCESS
   else

--- a/site/profiles/manifests/jenkins.pp
+++ b/site/profiles/manifests/jenkins.pp
@@ -102,4 +102,12 @@ class profiles::jenkins (
     ensure   => 'installed',
     provider => 'gem',
   }
+
+  jenkins::job { 'jenkins-job-puppet-artifact-create':
+    config => template('profiles/jenkins-job-puppet-artifact-create.xml.erb')
+  }
+
+  jenkins::job { 'jenkins-job-puppet-deploy':
+    config => template('profiles/jenkins-job-puppet-deploy.xml.erb')
+  }
 }

--- a/site/profiles/templates/jenkins-job-puppet-artifact-create.xml.erb
+++ b/site/profiles/templates/jenkins-job-puppet-artifact-create.xml.erb
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.3.5">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/LandRegistry-Ops/puppet-control.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>http://gitlab/webops/puppet-secrets.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command># Run tests
+#bundle install
+#bundle exec rake validate</command>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command># Build artifact
+/usr/local/bin/artifact https://github.com/LandRegistry-Ops/puppet-control.git http://gitlab/webops/puppet-secrets.git</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.BuildTrigger>
+      <childProjects>Puppet deployment</childProjects>
+      <threshold>
+        <name>UNSTABLE</name>
+        <ordinal>1</ordinal>
+        <color>YELLOW</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </hudson.tasks.BuildTrigger>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/site/profiles/templates/jenkins-job-puppet-deploy.xml.erb
+++ b/site/profiles/templates/jenkins-job-puppet-deploy.xml.erb
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>export PUPPET_MASTER=puppet
+/usr/local/bin/deploy</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
These changes automate the configuration of the jenkins jobs required for the puppet pipe line:

Puppet artefact create pulls down all branches of the puppet control repo and combines this code with secrets held in the corresponding branches of a private git repository and bundles it in to an artefact.

Puppet deploy deploys the artefact to the puppet master.

With these jobs in place the only manual step required to deploy an environment with a puppet pipe line is to set up the git repository containing the secrets.  