### PR TITLE
Add nat profile for use on AWS and enable nat rules in iptables

### DIFF
--- a/hiera/roles/nat.yaml
+++ b/hiera/roles/nat.yaml
@@ -1,0 +1,7 @@
+---
+
+classes:
+  - 'profiles::nat'
+
+profiles::firewall::firewall_state: 'on'
+profiles::firewall::nat: '10.100.20.0/24'

--- a/site/profiles/manifests/firewall.pp
+++ b/site/profiles/manifests/firewall.pp
@@ -23,6 +23,7 @@ class profiles::firewall (
 
   $firewall_state    = 'off',
   $ssh_allowed_range = '0.0.0.0/0',
+  $nat               = undef,
   $services          = {}
 
   ){

--- a/site/profiles/manifests/nat.pp
+++ b/site/profiles/manifests/nat.pp
@@ -1,0 +1,42 @@
+# Class profiles::nat
+# This class will set up a nat instance primarily for use on AWS
+# Currently supports stand-alone only.
+#
+# Parameters:
+#  ['jenkins_plugins'] - Accepts a hash of Jenkins Plugins
+#
+# Requires:
+# - rtyler/jenkins
+# - puppetlabs/firewall
+#
+# Sample Usage:
+#   class { 'profiles::jenkins': }
+#
+# Hiera:
+#   profiles::jenkins::plugins:
+#     git:
+#       version: latest
+#
+class profiles::nat (
+
+  $private_sub_net = undef
+
+  ){
+
+  # Enable ipv4 forwarding
+  file { '/etc/sysctl.d/ip_forward.conf':
+    ensure  => present,
+    content => 'net.ipv4.ip_forward = 1',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Exec ['reload system config']
+  }
+  exec { 'reload system config' :
+    command     => '/usr/sbin/sysctl -p',
+    refreshonly => true
+  }
+
+  # IP tables rules will be added via hiera
+
+}

--- a/site/profiles/templates/iptables.conf.erb
+++ b/site/profiles/templates/iptables.conf.erb
@@ -71,5 +71,12 @@
 # first go. If the machine then tries to connect again more than 3 times in 15
 # seconds or 5 times in 15 minutes their connection is dropped.
 #
+COMMIT
 
+*nat
+#-A POSTROUTING -s 10.100.20.0/24 -j MASQUERADE
+<% puts nat.inspect -%>
+<% if @nat -%>
+-A POSTROUTING -s <%= @nat %> -j MASQUERADE
+<% end -%>
 COMMIT


### PR DESCRIPTION
This change should enable the automated creation of nat instances in AWS