### PR TITLE
Add SSL config to Gitlab profile

### DIFF
--- a/site/profiles/manifests/gitlab.pp
+++ b/site/profiles/manifests/gitlab.pp
@@ -26,6 +26,9 @@ class profiles::gitlab (
   $ldap_base       = undef,
   $ldap_bind_dn    = undef,
   $ldap_password   = undef,
+  $gitlab_crt      = '',
+  $gitlab_key      = '',
+  $https_redirect  = false
 
 ){
 
@@ -33,6 +36,29 @@ class profiles::gitlab (
     CentOS     => 'https://downloads-packages.s3.amazonaws.com/centos-7.0.1406/gitlab-7.5.1_omnibus.5.2.0.ci-1.el7.x86_64.rpm',
     Redhat     => 'https://downloads-packages.s3.amazonaws.com/centos-7.0.1406/gitlab-7.5.1_omnibus.5.2.0.ci-1.el7.x86_64.rpm',
     Ubuntu     => 'https://downloads-packages.s3.amazonaws.com/ubuntu-14.04/gitlab_7.5.1-omnibus.5.2.0.ci-1_amd64.deb',
+  }
+
+  file { '/etc/gitlab/ssl' :
+    ensure => directory,
+    owner  => root,
+    group  => root,
+    mode   => '0700'
+  }
+
+  file { '/etc/gitlab/ssl/gitlab.crt' :
+    ensure  => present,
+    content => $gitlab_crt,
+    owner   => root,
+    group   => root,
+    mode    => '0644'
+  }
+
+  file { '/etc/gitlab/ssl/gitlab.key' :
+    ensure  => present,
+    content => $gitlab_key,
+    owner   => root,
+    group   => root,
+    mode    => '0400'
   }
 
   class { '::gitlab' :
@@ -57,7 +83,14 @@ class profiles::gitlab (
     ldap_base                     => $ldap_base,
     ldap_bind_dn                  => $ldap_bind_dn,
     ldap_password                 => $ldap_password,
-    ldap_uid                      => 'sAMAccountName'
+    ldap_uid                      => 'sAMAccountName',
+
+    #ssl configuration
+    ssl_certificate               => '/etc/gitlab/ssl/gitlab.crt',
+    ssl_certificate_key           => '/etc/gitlab/ssl/gitlab.key',
+    redirect_http_to_https        => true,
+    require                       => File['/etc/gitlab/ssl/gitlab.crt', '/etc/gitlab/ssl/gitlab.key']
+
   }
 
   #ensure that nfs package is installed


### PR DESCRIPTION
Add the ability to configure SSL for gitlab web interface via hiera. 