### PR TITLE
Feature static error page

### DIFF
--- a/hiera/roles/digital-register-frontend.yaml
+++ b/hiera/roles/digital-register-frontend.yaml
@@ -4,6 +4,7 @@
 
   classes:
     - profiles::digitalregister_app
+    #- profiles::https_redirect
 
   applications:
     digital-register-frontend:
@@ -20,3 +21,65 @@
         APPLICATION_SECRET_KEY: 'secretkeyshouldberandom'
         LOGIN_API: 'http://landregistry.local:8005/'
         SESSION_COOKIE_SECURE: 'False'
+        SERVICE_NOTICE_HTML: '<h2>Downtime notice</h2><p>This service will be offline between 2.00&ndash;5.00 on 31st July</p>'
+        MORE_PROPRIETOR_DETAILS: 'true'
+        SHOW_FULL_TITLE_DATA: 'true'
+
+  profiles::https_redirect::server_name: localhost
+
+  profiles::digitalregister_app::port: 80
+
+  profiles::digitalregister_app::frontend_ssl: true
+
+  profiles::digitalregister_app::ssl_crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfzCCAmegAwIBAgIJAOHewZLH4GsjMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+    BAYTAkdCMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg
+    Q29tcGFueSBMdGQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xNTA3MTYxNjI4NTla
+    Fw0yNTA3MTMxNjI4NTlaMFYxCzAJBgNVBAYTAkdCMRUwEwYDVQQHDAxEZWZhdWx0
+    IENpdHkxHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEjAQBgNVBAMMCWxv
+    Y2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOjrI8HXLJid
+    15/JoPupid/WNz6DNjV3+Y+26vP4/KtIeEInWY5sJlQe3SVGJsI4bIZYrtZq+wIl
+    sORmkv6GpA5PVdZ6c9AA1j+oZusTBmvtpAEXpoYZ3BOsw3bKScv51sF2FAMrc4YB
+    hnQEM02RfNdXVSibDwDh3cNyiIMwQMX0uUr5HhGVFBJZJDRHPs3bE34PDI9baEJw
+    5K6L0dWXD9yhLj+7oAOgTv8TOi3q2UJMoNgU5dnx//kaufGLzw1atWyd5TjhxwES
+    7VvwNT0vV9JkPaFabIPkpjj6GgHE20OXRcCdTcViq+k7W4W82SCUjhhs9pIqDsxx
+    NEkeuAX1RiECAwEAAaNQME4wHQYDVR0OBBYEFKlJjaNawsWG+s/QPDYKKgahTcpv
+    MB8GA1UdIwQYMBaAFKlJjaNawsWG+s/QPDYKKgahTcpvMAwGA1UdEwQFMAMBAf8w
+    DQYJKoZIhvcNAQELBQADggEBAGk3Sw3aoki2DYIcSSKoR1h68TYFrY58oP9QA+sW
+    91q5Pao/Jdw8mCaGtxfRGhcXaWbDQWihCH9iFtgMMuGe+l/LWdDOdmes+ir/Dv3w
+    PhQMT6g89LIR3mQ8fSIH69res2tflbPtaQze4tRRfRirgqf4fcIdqPJ3grHq9cne
+    OKsrRtK32IHStq2urAKTjzrbinMFGVqbntt1metJTNsb/1PN0/Ambrkxa6LX02uu
+    mR5JKapqlWDV9uMfjTjDM1biT4SgrlrNX2B0WAPu810qMWp7dANO96Q6RJhm2PwB
+    NMc95xkmMe9ioG3hSBkqfSF8ZjCRIiQDQaFoRE96hnToyXA=
+    -----END CERTIFICATE-----
+
+  profiles::digitalregister_app::ssl_key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDo6yPB1yyYndef
+    yaD7qYnf1jc+gzY1d/mPturz+PyrSHhCJ1mObCZUHt0lRibCOGyGWK7WavsCJbDk
+    ZpL+hqQOT1XWenPQANY/qGbrEwZr7aQBF6aGGdwTrMN2yknL+dbBdhQDK3OGAYZ0
+    BDNNkXzXV1Uomw8A4d3DcoiDMEDF9LlK+R4RlRQSWSQ0Rz7N2xN+DwyPW2hCcOSu
+    i9HVlw/coS4/u6ADoE7/Ezot6tlCTKDYFOXZ8f/5Grnxi88NWrVsneU44ccBEu1b
+    8DU9L1fSZD2hWmyD5KY4+hoBxNtDl0XAnU3FYqvpO1uFvNkglI4YbPaSKg7McTRJ
+    HrgF9UYhAgMBAAECggEAbi5dmeLKC+APEl11M9d9i09wjrfPOvfoLF3hQ0wzams7
+    yD+JE+CBOSXogytuRk4euGbXPkMZPmjKByGmw5S5orNQ7ca7ZlgfAboOBYHYddHS
+    1Vl0wtcUzpHZXSZQRpeHSbkrulwhp/Csw9EA297I6a08cZr4O/icyUoy3axD1+AH
+    h6RstpVAAyynaJznodhgDblz4uGTFRnT5CRwVyxZQiJ6vj4gRaA6bEXYYIYh0T/1
+    lnFTcRM+vWwKV9JcfyzW/Hz1hO3D1YfMtTnX8lurQ8Af9aQRo9p/o1ERGl526WWD
+    azcKjPxRuwt155p5Q/QzFnXSToeNqDovgMGHZBA44QKBgQD1dqFR+muUUUms77Md
+    Gsq6PrwAq30xzg2z92zxX3OoxiePP7pJOM65TQx1m3ENLx5rYYHk3pNT3WYQZGm0
+    UWiX82qnJ3tsqN2iP80f7Yv1lVWjTS487sNQWpRxbsRuUD7+jPGJBCV4az5SIVBp
+    wfg+1SaCzzNLI0vVXANx6B2lNQKBgQDy6qe6Kc7TkIidlsFII+2ArzwLTy/2a4+X
+    UtrdIO5vcL+jQUP9VQuvMMb/cgDBZRBkaYUQ6mc2TP8p6FLWdvfDDxub/XSdmYc9
+    OpHbSsDAKhpQfewledifsU4e/ex7OIGkQhnxR3ubC/3axyn83fqrCBPkrBNAUXgD
+    sHAtNxjWvQKBgQCPw5tYWEMJ61IrZ3iQY1C5JGUYP1hkAzsjXJcCB9XF08j3rWt9
+    1ze8b9QMTa44+o/mdIWPdozzYYiVsTn30nZgCME+hXFUgtLMZHHPcWG3xG8T5fBe
+    37ilJ2gpx6Zktbsve307sqH/lVA66igeyOyMYGrd0l1IdLPFks6xuDEkwQKBgGN+
+    v2Jd22wGSB6b7+C3boEFxUcwkQmSdsbZVfG6mk6k1KlugwWRPu7rwKZCMJMF7Rfj
+    rHAIQmwYT27/zGYxZjvLxVg4EPq4No9anQE/9gD/fbW4Te/vn02RVtkU0jaKJ3d6
+    55tO1w7jc3+XkdgTp6dD8Ln5zQzMEacZLmkmpxLVAoGAAKczdsBxismnLZokNqWP
+    o01usaxPsTMJSQ2RoUWSeC15tyFMlllMlo0qtkjKveui574KRDlW2E40Ej6qwtgO
+    uWLEl7PF7nFGUM7Btv23iWH84nZZgUFDcayXV288Pzba1miTosRI6F3tAXdiI4o3
+    wU96va4MvaWpYSkYb5zQbng=
+    -----END PRIVATE KEY-----

--- a/site/profiles/manifests/digitalregister_app.pp
+++ b/site/profiles/manifests/digitalregister_app.pp
@@ -10,18 +10,21 @@
 #
 class profiles::digitalregister_app(
 
-  $application  = undef,
-  $bind         = '5000',
-  $source       = 'undef',
-  $vars         = {},
-  $wsgi_entry   = undef,
-  $manage       = true,
-  $app_type     = 'wsgi',
-  $applications = hiera_hash('applications',false),
-  $port         = 80,
-  $ssl          = false,
-  $ssl_crt      = '',
-  $ssl_key      = ''
+  $application   = undef,
+  $bind          = '5000',
+  $source        = 'undef',
+  $vars          = {},
+  $wsgi_entry    = undef,
+  $manage        = true,
+  $app_type      = 'wsgi',
+  $applications  = hiera_hash('applications',false),
+  $port          = 80,
+  $frontend_ssl  = false,
+  $api_ssl       = false,
+  $ssl_protocols = 'TLSv1 SSLv3',
+  $ssl_ciphers   = 'RC4:HIGH:!aNULL:MD5:@STRENGTH',
+  $ssl_crt       = '',
+  $ssl_key       = ''
 
   ){
 
@@ -67,13 +70,15 @@ class profiles::digitalregister_app(
     create_resources('wsgi::application', $applications)
   }
 
-  #Dirty hack required for static error page (should be removed asap)
-  #set up static error page
-  vcsrepo { '/usr/share/nginx/html/digital-register-static-error-page':
-    ensure   => present,
-    provider => git,
-    source   => 'https://github.com/LandRegistry/digital-register-static-error-page.git',
-    before   => File['/etc/ssl/keys/']
+  if $::puppet_role == 'digital-register-frontend' {
+    #Dirty hack required for static error page (should be removed asap)
+    #set up static error page
+    vcsrepo { '/usr/share/nginx/html/digital-register-static-error-page':
+      ensure   => present,
+      provider => git,
+      source   => 'https://github.com/LandRegistry/digital-register-static-error-page.git',
+      before   => File['/etc/ssl/keys/']
+    }
   }
 
   # Set up Nginx proxy
@@ -109,28 +114,48 @@ class profiles::digitalregister_app(
             'return' => '301 https://$server_name$request_uri'}
   }
 
-  nginx::resource::vhost { 'api_proxy':
-    server_name         => [ $::hostname ],
-    listen_port         => 443,
+  if $::puppet_role == 'digital-register-frontend' {
+    nginx::resource::vhost { 'frontend_proxy':
+      server_name       => [ $::hostname ],
+      listen_port       => 443,
 
-    proxy_set_header    => ['X-Forward-For $proxy_add_x_forwarded_for',
-      'X-Real-IP $remote_addr', 'Client-IP $remote_addr', 'Host $http_host'],
+      proxy_set_header  => ['X-Forward-For $proxy_add_x_forwarded_for',
+        'X-Real-IP $remote_addr', 'Client-IP $remote_addr', 'Host $http_host'],
 
-    proxy_redirect    => 'off',
-    proxy             => 'http://127.0.0.1:5000',
-    ssl               => $ssl,
-    ssl_cert          => '/etc/ssl/certs/ssl.crt',
-    ssl_key           => '/etc/ssl/keys/ssl.key',
-    require           => File['/etc/ssl/certs/ssl.crt','/etc/ssl/keys/ssl.key'],
+      proxy_redirect    => 'off',
+      proxy             => 'http://127.0.0.1:5000',
+      ssl               => $frontend_ssl,
+      ssl_cert          => '/etc/ssl/certs/ssl.crt',
+      ssl_key           => '/etc/ssl/keys/ssl.key',
+      ssl_protocols     => $ssl_protocols,
+      ssl_ciphers       => $ssl_ciphers,
+      require           => File['/etc/ssl/certs/ssl.crt',
+                                '/etc/ssl/keys/ssl.key'],
 
-    vhost_cfg_prepend => {
-        'error_page' => '502 /index.html',
-        'root'       => '/usr/share/nginx/html/digital-register-static-error-page/service-unavailable'
-        },
+      vhost_cfg_prepend => {
+          'error_page' => '502 /index.html',
+          'root'       => '/usr/share/nginx/html/digital-register-static-error-page/service-unavailable'
+          },
 
-    raw_append        => ['','location /index.html {',
-      '  root /usr/share/nginx/html/digital-register-static-error-page/service-unavailable;'
-      ,'  internal;','}']
+      raw_append        => ['','location /index.html {',
+        '  root /usr/share/nginx/html/digital-register-static-error-page/service-unavailable;'
+        ,'  internal;','}']
+    }
+  } else {
+    nginx::resource::vhost { 'api_proxy':
+      server_name    => [ $::hostname ],
+      listen_port    => 80,
+      # proxy_set_header => ['X-Forward-For $proxy_add_x_forwarded_for',
+      # 'X-Real-IP $remote_addr', 'Client-IP $remote_addr', 'Host $http_host'],
+      proxy_redirect => 'off',
+      proxy          => 'http://127.0.0.1:5000',
+      ssl            => $api_ssl,
+      ssl_cert       => '/etc/ssl/certs/ssl.crt',
+      ssl_key        => '/etc/ssl/keys/ssl.key',
+      ssl_protocols  => $ssl_protocols,
+      ssl_ciphers    => $ssl_ciphers,
+      require        => File['/etc/ssl/certs/ssl.crt',
+      '/etc/ssl/keys/ssl.key'],
+    }
   }
-
 }

--- a/site/profiles/manifests/digitalregister_app.pp
+++ b/site/profiles/manifests/digitalregister_app.pp
@@ -67,6 +67,15 @@ class profiles::digitalregister_app(
     create_resources('wsgi::application', $applications)
   }
 
+  #Dirty hack required for static error page (should be removed asap)
+  #set up static error page
+  vcsrepo { '/usr/share/nginx/html/digital-register-static-error-page':
+    ensure   => present,
+    provider => git,
+    source   => 'https://github.com/LandRegistry/digital-register-static-error-page.git',
+    before   => File['/etc/ssl/keys/']
+  }
+
   # Set up Nginx proxy
   file { '/etc/ssl/keys/' :
     ensure => directory,
@@ -92,18 +101,36 @@ class profiles::digitalregister_app(
     require => File['/etc/ssl/keys/']
   }
 
-  nginx::resource::vhost { 'api_proxy':
-    server_name    => [ $::hostname ],
-    listen_port    => $port,
-
-    #proxy_set_header => ['X-Forward-For $proxy_add_x_forwarded_for',
-      #'Host $http_host'],
-
-    proxy_redirect => 'off',
-    proxy          => 'http://127.0.0.1:5000',
-    ssl            => $ssl,
-    ssl_cert       => '/etc/ssl/certs/ssl.crt',
-    ssl_key        => '/etc/ssl/keys/ssl.key',
-    require        => File['/etc/ssl/certs/ssl.crt','/etc/ssl/keys/ssl.key']
+  nginx::resource::vhost { 'https_redirect':
+    server_name      => [ $::hostname ],
+    listen_port      => $port,
+    www_root         => '/usr/share/nginx/html',
+    vhost_cfg_append => {
+            'return' => '301 https://$server_name$request_uri'}
   }
+
+  nginx::resource::vhost { 'api_proxy':
+    server_name         => [ $::hostname ],
+    listen_port         => 443,
+
+    proxy_set_header    => ['X-Forward-For $proxy_add_x_forwarded_for',
+      'X-Real-IP $remote_addr', 'Client-IP $remote_addr', 'Host $http_host'],
+
+    proxy_redirect    => 'off',
+    proxy             => 'http://127.0.0.1:5000',
+    ssl               => $ssl,
+    ssl_cert          => '/etc/ssl/certs/ssl.crt',
+    ssl_key           => '/etc/ssl/keys/ssl.key',
+    require           => File['/etc/ssl/certs/ssl.crt','/etc/ssl/keys/ssl.key'],
+
+    vhost_cfg_prepend => {
+        'error_page' => '502 /index.html',
+        'root'       => '/usr/share/nginx/html/digital-register-static-error-page/service-unavailable'
+        },
+
+    raw_append        => ['','location /index.html {',
+      '  root /usr/share/nginx/html/digital-register-static-error-page/service-unavailable;'
+      ,'  internal;','}']
+  }
+
 }


### PR DESCRIPTION
Add Nginx config to display static error page when Gunicorn is unavailable (502) + additional SSL config to control SSL cipher suites and TLS protocols. 