### PR TITLE
Include PDF gen deps on frontend

### DIFF
--- a/site/profiles/manifests/digitalregister_app.pp
+++ b/site/profiles/manifests/digitalregister_app.pp
@@ -116,6 +116,15 @@ class profiles::digitalregister_app(
   }
 
   if $::puppet_role == 'digital-register-frontend' {
+
+    $FRNTEND_PKGS = ['cairo','pango','gdk-pixbuf2','libffi-devel',
+                    'libxslt-devel','libxml2-devel']
+
+    package{ $FRNTEND_PKGS :
+      ensure  => installed,
+      require => Package[epel-release]
+    }
+
     nginx::resource::vhost { 'frontend_proxy':
       server_name       => [ $frontend_url ],
       listen_port       => 443,


### PR DESCRIPTION
Includes packages required for PDF generation on DR front end.

NB we will need to revisit the way we include packages on hosts in the near future