### PR TITLE
Added Server Types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ and stored in __/etc/puppetlabs/facter/facts.d/__.
 
 * __network_location__: The location on the network the server will reside (e.g. zone1, zone2)
 * __puppet_role__: The hiera profile name that the machine will apply (e.g. migration-app)
+* __server_type__: Similar to 'puppet_role' but specific to an environment.
 * __application_environment__: The environment name of the application (e.g. production, pre-production)
 * __hosting_platform__: The platform the code will be hosted on (e.g. aws, internal, vagrant)
 
 _/etc/puppetlabs/facter/facts.d/host.yaml_
 ```
 network_location: zone1
-puppet_role: migration-app
+puppet_role: digital-register-frontend
+server_type: drf-production
 application_environment: production
 hosting_platform: aws
 ```

--- a/site/profiles/files/hiera.yaml
+++ b/site/profiles/files/hiera.yaml
@@ -5,7 +5,7 @@
   :datadir: /etc/puppet/environments/%{environment}/hiera
 :hierarchy:
   - secrets/nodes/%{::fqdn}
-  - secrets/types/${::server_type}
+  - secrets/types/%{::server_type}
   - secrets/application_environment/%{::application_environment}
   - secrets/secrets
   - application_environment/%{::application_environment}

--- a/site/profiles/files/hiera.yaml
+++ b/site/profiles/files/hiera.yaml
@@ -5,9 +5,11 @@
   :datadir: /etc/puppet/environments/%{environment}/hiera
 :hierarchy:
   - secrets/nodes/%{::fqdn}
+  - secrets/types/${::server_type}
   - secrets/application_environment/%{::application_environment}
   - secrets/secrets
   - application_environment/%{::application_environment}
   - hosts/%{::fqdn}
+  - types/${::server_type}
   - roles/%{::puppet_role}
   - common


### PR DESCRIPTION
Although I don't feel this is an appropriate long-term solution, the server_types fact will allow you to set up a configuration for a group of servers which perform identical functions in the same application environment (digital-register-frontend in Production for example). For this part this is simply 'roles' all over again, although roles are more a vague configuration than this.

Long term I feel something like below would be more appropriate but until we can guarantee hiera deep merges will not have any unforeseen consequences I think this implementation is safer.

In the future:
```
hiera:
  - nodes/%{::fqdn}
  - types/%{::region}/%{::type}
  - regions/${::region}
  - common
```
and machine facts:
```
type: digital-register-frontend
network_location: internal
region: production
```