### PR TITLE
Fixed missing dependency in Puppetfile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -37,7 +37,7 @@ mod 'puppet-gradle_deploy',            :git => 'https://github.com/LandRegistry-
 mod 'camptocamp/archive',              '0.8.1'
 
 # Dependency modules
-mod 'ceritsc/yum'                      '0.9.6'
+mod 'ceritsc/yum',                     '0.9.6'
 mod 'croddy/make',                     '0.0.5'
 mod 'darin/zypprepo',                  '1.0.2'
 mod 'garethr/erlang',                  '0.3.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -37,6 +37,7 @@ mod 'puppet-gradle_deploy',            :git => 'https://github.com/LandRegistry-
 mod 'camptocamp/archive',              '0.8.1'
 
 # Dependency modules
+mod 'ceritsc/yum'                      '0.9.6'
 mod 'croddy/make',                     '0.0.5'
 mod 'darin/zypprepo',                  '1.0.2'
 mod 'garethr/erlang',                  '0.3.0'


### PR DESCRIPTION
It seems that when I bumped the version of the elasticsearch/elasticsearch module to 0.9.9 in commit 495c2e3 I failed to include the module ceritsc/yum which is a required dependency. Unfortunately because of differences between librarian-puppet and R10K this was not picked up in testing as librarian-puppet will resolve dependencies that are not explicitly stated in the Puppetfile.

I've include this module now and hopefully it won't cause further issues but it does highlight a weakness in our testing.