### PR TITLE
Added application profile

### DIFF
--- a/site/profiles/manifests/application.pp
+++ b/site/profiles/manifests/application.pp
@@ -1,0 +1,12 @@
+#
+class profiles::application (
+  $applications = hiera_hash('applications',false)
+){
+  include ::wsgi
+  include ::stdlib
+
+  if $applications {
+    create_resources('wsgi::application', $applications)
+  }
+
+}


### PR DESCRIPTION
Adds an additional 'profile' which allows you to use the `applications` hash in hiera without requiring the `digitalregister_app` profile, getting rid of any requirement to run Nginx on port 80. This is to compliment the work done with the load balancing module.

This *shouldn't* break anything so long as no one feels crazy enough to assign both the `application` and `digitalregister_app` profiles onto the same machine, which would likely result in a duplicate declaration.
