### PR TITLE
Add high availabillity to rabbit profile

### DIFF
--- a/site/profiles/manifests/rabbitmq.pp
+++ b/site/profiles/manifests/rabbitmq.pp
@@ -19,8 +19,14 @@ class profiles::rabbitmq(
 
   $port              = 5672,
   $version           = '3.4.4',
-  $delete_guest_user = true
-  
+  $delete_guest_user = true,
+  $default_user      = 'guest',
+  $default_pass      = 'guest',
+  $cluster           = false,
+  $cluster_nodes     = [],
+  $erlang_cookie     = 'super_secret_key',
+  $admin_enable      = false
+
 ){
 
   # Load SELinuux policy for RabbitMQ
@@ -40,12 +46,36 @@ class profiles::rabbitmq(
 
   include ::erlang
 
-  class { '::rabbitmq':
-    version           => $ver,
-    port              => $port,
-    require           => Class[erlang],
-    delete_guest_user => $delete_guest_user
+  case $cluster {
+    true : {
+      class { '::rabbitmq':
+        version                  => $ver,
+        port                     => $port,
+        default_user             => $default_user,
+        default_pass             => $default_pass,
+        delete_guest_user        => $delete_guest_user,
+        cluster_nodes            => $cluster_nodes,
+        cluster_node_type        => 'disc',
+        erlang_cookie            => $erlang_cookie,
+        wipe_db_on_cookie_change => true,
+        config_cluster           => true,
+        admin_enable             => $admin_enable,
+        require                  => Class[erlang]
+      }
+    }
+    default : {
+      class { '::rabbitmq':
+        version           => $ver,
+        port              => $port,
+        default_user      => $default_user,
+        default_pass      => $default_pass,
+        delete_guest_user => $delete_guest_user,
+        admin_enable      => $admin_enable,
+        require           => Class[erlang]
+      }
+    }
   }
+
 
   include stdlib
 


### PR DESCRIPTION
This change adds high availability functionality to the rabbit profile.

NB The 'clustered nodes' variable must  be configured with the host names (not FQDN's or IP addresses) of all of the nodes in the cluster. Each node must therefore  be able to resolve all nodes by their host names in order for clustering to work. 