### PR TITLE
Install packags in hiera + install fonts for PDF generation

### DIFF
--- a/site/profiles/manifests/fonts.pp
+++ b/site/profiles/manifests/fonts.pp
@@ -1,0 +1,8 @@
+# install fonts requied for PDF geneation
+class profiles::fonts {
+  file { '/usr/share/fonts/':
+    ensure  => directory,
+    source  => 'puppet:///modules/profiles/fonts',
+    recurse => true,
+  }
+}

--- a/site/profiles/manifests/packages.pp
+++ b/site/profiles/manifests/packages.pp
@@ -1,0 +1,14 @@
+#
+class profiles::packages (
+
+  $packages = hiera_array(packages)
+
+){
+    include ::stdlib
+
+    if $packages {
+      package{ $packages :
+        ensure  => installed,
+      }
+    }
+  }


### PR DESCRIPTION
This change is required following the introduction of the 'types' puppet fact to ensure that system packages are installed on application servers. Additionally this change also includes a fonts profile to install the fonts required for PDF generation on the front end machines. 