### PR TITLE
Half number of unicorn workers on puppet master

### DIFF
--- a/site/profiles/files/puppet_master_unicorn.conf
+++ b/site/profiles/files/puppet_master_unicorn.conf
@@ -1,4 +1,4 @@
-worker_processes 8
+worker_processes 4
   working_directory "/etc/puppet"
   listen '/var/run/puppet/puppetmaster_unicorn.sock', :backlog => 512
   timeout 120


### PR DESCRIPTION
This change should alleviate recent issues with puppet master stability in AWS. 