### PR TITLE
Manage heap size for elasticsearch

### DIFF
--- a/site/es/manifests/init.pp
+++ b/site/es/manifests/init.pp
@@ -18,6 +18,11 @@ class es (
   } else {
     $listen = $::ipaddress
   }
+  if ($::memorysize_mb >= 1024) {
+    $heap_size = $::memorysizeinbytes/2
+  } else {
+    $heap_size = 268435456
+  }
   $repo_version = '1.7'
   $version      = '1.7.3'
   $data_dir = "/var/lib/elasticsearch/${cluster_name}/data"
@@ -38,8 +43,11 @@ class es (
   }
 
   elasticsearch::instance { $cluster_name :
-    datadir => $data_dir,
-    config  => {
+    datadir       => $data_dir,
+    init_defaults => {
+      'ES_HEAP_SIZE' => $heap_size
+    },
+    config        => {
       'cluster.name'  => $cluster_name,
       'path.repo'     => "[${backup_dir}]",
       'path.logs'     => $log_dir,

--- a/site/profiles/lib/facter/meminbytes.rb
+++ b/site/profiles/lib/facter/meminbytes.rb
@@ -1,0 +1,48 @@
+# meminbytes.rb
+# Additional Facts for memory/swap usage in bytes
+#
+# Original file:
+# Copyright (C) 2006 Mooter Media Ltd
+# Author: Matthew Palmer <matt@solutionsfirst.com.au>
+#
+# Modifications by: Rutger Spiertz, Kumina BV
+#
+require 'thread'
+
+{   :MemorySizeInBytes => "MemTotal",
+    :MemoryFreeInBytes => "MemFree",
+    :SwapSizeInBytes   => "SwapTotal",
+    :SwapFreeInBytes   => "SwapFree"
+}.each do |fact, name|
+    Facter.add(fact) do
+        confine :kernel => :linux
+        setcode do
+            meminfo_number(name)
+        end
+    end
+end
+
+def meminfo_number(tag)
+    memsize = ""
+    Thread::exclusive do
+        size, scale = [0, ""]
+        File.readlines("/proc/meminfo").each do |l|
+            size, scale = [$1.to_f, $2] if l =~ /^#{tag}:\s+(\d+)\s+(\S+)/
+            # MemoryFree == memfree + cached + buffers
+            #  (assume scales are all the same as memfree)
+            if tag == "MemFree" &&
+                l =~ /^(?:Buffers|Cached):\s+(\d+)\s+(?:\S+)/
+                size += $1.to_f
+            end
+        end
+        memsize = scale_number(size, scale)
+    end
+
+    memsize
+end
+
+def scale_number(size, multiplier)
+    suffixes = ['', 'kB', 'MB', 'GB', 'TB']
+    size *= 1024 ** suffixes.index(multiplier)
+    return "%.0f" % size
+end


### PR DESCRIPTION
This change will set the heap size for elastic search to half of the system memory (in accordance with the suggested heap size in the elastic search documentation. 