### PR TITLE
Pg development

### DIFF
--- a/site/profiles/manifests/postgresqlha_master.pp
+++ b/site/profiles/manifests/postgresqlha_master.pp
@@ -253,41 +253,6 @@ class profiles::postgresqlha_master(
       content => $ssh_keys['public'],
       owner   => 'postgres',
       mode    => '0644',
-    } ->
-
-    file { '/home/repmgr/.ssh' :
-      ensure  => directory,
-      owner   => 'repmgr',
-      mode    => '0700',
-      require => Package["repmgr${shortversion}"],
-    } ->
-
-    file { '//home/repmgr/.ssh/config' :
-      ensure  => file,
-      content => 'StrictHostKeyChecking no',
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/authorized_keys' :
-      ensure  => file,
-      content => $ssh_keys['public'],
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/id_rsa' :
-      ensure  => file,
-      content => $ssh_keys['private'],
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/id_rsa.pub' :
-      ensure  => file,
-      content => $ssh_keys['public'],
-      owner   => 'repmgr',
-      mode    => '0644',
     }
 
     include postgresql::client

--- a/site/profiles/manifests/postgresqlha_standby.pp
+++ b/site/profiles/manifests/postgresqlha_standby.pp
@@ -144,41 +144,6 @@ class profiles::postgresqlha_standby (
       mode    => '0644',
     } ->
 
-    file { '/home/repmgr/.ssh' :
-      ensure  => directory,
-      owner   => 'repmgr',
-      mode    => '0700',
-      require => Package["repmgr${shortversion}"],
-    } ->
-
-    file { '//home/repmgr/.ssh/config' :
-      ensure  => file,
-      content => 'StrictHostKeyChecking no',
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/authorized_keys' :
-      ensure  => file,
-      content => $ssh_keys['public'],
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/id_rsa' :
-      ensure  => file,
-      content => $ssh_keys['private'],
-      owner   => 'repmgr',
-      mode    => '0600',
-    } ->
-
-    file { '/home/repmgr/.ssh/id_rsa.pub' :
-      ensure  => file,
-      content => $ssh_keys['public'],
-      owner   => 'repmgr',
-      mode    => '0644',
-    }
-
     file { "/etc/repmgr/${version}/repmgr.conf" :
       ensure  => file,
       content => template('profiles/postgres_repmgr_config.erb'),
@@ -245,7 +210,7 @@ class profiles::postgresqlha_standby (
     service { 'repmgr' :
       ensure  => running,
       enable  => true,
-      require => File['/usr/lib/systemd/system/repmgr.service']
+      require => File['/usr/lib/systemd/system/repmgr.service'],
     } ->
 
     file { '/usr/lib/systemd/system/postgresql.service' :

--- a/site/profiles/templates/postgres_keepalived_config.erb
+++ b/site/profiles/templates/postgres_keepalived_config.erb
@@ -13,7 +13,7 @@ vrrp_script postgresql-9.4 {
   interval 2
   wait 2
 }
-vrrp_instance PG-CLUSTER {
+vrrp_instance <%= @application_environment.upcase %>-PG-CLUSTER {
     state MASTER
     interface eth1
     virtual_router_id 100


### PR DESCRIPTION
Remove unused repmgr users config files from manifests, give keepalived vrrp_instances unique names to allow multiple postgres repmgr clusters on the same subnet.