### PR TITLE
Tomcat

### DIFF
--- a/site/ha/manifests/init.pp
+++ b/site/ha/manifests/init.pp
@@ -20,12 +20,14 @@ class ha (
   $lb_instances = undef,
   $interface   = 'eth0',
   $virtual_ip  = undef,
+  $sticky      = false
 ) {
 
   include stdlib
   validate_hash($lb_instances)
   validate_string($interface)
   validate_string($virtual_ip)
+  validate_bool($sticky)
 
   unless has_interface_with($interface) {
     fail("${interface} is not a valid network port")

--- a/site/ha/templates/haproxy.conf.erb
+++ b/site/ha/templates/haproxy.conf.erb
@@ -20,9 +20,20 @@ defaults
 <% @lb_instances.each do |name,config| -%>
 listen <%= name %> *:<%= config['port'] %>
     balance roundrobin
+
+<% if @sticky == true -%>
+    cookie JSESSIONID prefix
     option httpchk GET  <%= config['healthcheck'] %>
+<% config['backends'].each do |backend| -%>
+    server <%= backend.split(':')[0] %> <%= backend %> cookie check
+<% end -%>
+<% end -%>
+
+<% else -%>
+    option httpchk GET <%=config['healthcheck'] %>
 <% config['backends'].each do |backend| -%>
     server <%= backend.split(':')[0] %> <%= backend %> check
 <% end -%>
 <% end -%>
+
 <% end -%>

--- a/site/ha/templates/haproxy.conf.erb
+++ b/site/ha/templates/haproxy.conf.erb
@@ -27,7 +27,6 @@ listen <%= name %> *:<%= config['port'] %>
 <% config['backends'].each do |backend| -%>
     server <%= backend.split(':')[0] %> <%= backend %> cookie check
 <% end -%>
-<% end -%>
 
 <% else -%>
     option httpchk GET <%=config['healthcheck'] %>
@@ -36,4 +35,5 @@ listen <%= name %> *:<%= config['port'] %>
 <% end -%>
 <% end -%>
 
+<% end -%>
 <% end -%>


### PR DESCRIPTION
In order to successfully implement load-balancing with stateful services we need to be able to support sticky sessions in HA Proxy.

Mark and I have made some modifications to the HA module to allow an optional parameter `sticky` to be set which will enable automatic sticky sessions based on cookies.

This is non-default behaviour and does not interfere with the usual behaviour.