### PR TITLE
remove recursive file resource control on environment folder

### DIFF
--- a/site/profiles/files/artifact.sh
+++ b/site/profiles/files/artifact.sh
@@ -123,9 +123,16 @@ done
 # Purge temp secrets directory
 #rm -rf ${TEMPDIR} 2>&1 >/dev/null
 
+# Ensure that file permissions are set to 644 for all regular files
+echo "Ensuring correct permissions" | output
+find ${DIR}/environments -type f -print0 | xargs -0 chmod 644 > /dev/null 2>&1
+# Ensure that the correct SE Linux user and type are set for all files
+echo "Ensuring correct SE Linux user and type"
+chcon -R -u system_u -t puppet_etc_t ${DIR}/environments/ > /dev/null 2>&1
+
 # Create compressed tar archive of the puppet enviroment code and dependancies
 echo "Attempting to create artifact" | output
-tar -C ${DIR} -czf ${DIR}/artifacts/${TIMESTAMP}.tgz environments/ > /dev/null 2>&1
+tar -C ${DIR} -czf ${DIR}/artifacts/${TIMESTAMP}.tgz environments/ --owner=puppet --group=puppet --selinux > /dev/null 2>&1
 if [[ $? == '0' ]]; then
   echo "Artifact successfully created" | output SUCCESS && exit 0
 else

--- a/site/profiles/files/deploy.sh
+++ b/site/profiles/files/deploy.sh
@@ -45,7 +45,7 @@ for PUPPET in ${PUPPETMASTER} ; do
   [[ $? != '0' ]] && echo "Error stopping puppetmaster service on ${PUPPET}" | output ERROR && exit 1
   ssh deployment@${PUPPET} "sudo rm -rf /etc/puppet/environments" #> /dev/null 2>&1
   [[ $? != '0' ]] && echo "Error purging existing environments on  ${PUPPET}" | output ERROR && exit 1
-  ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo tar -C /etc/puppet/ -xzf /tmp/${ARTIFACT}" > /dev/null 2>&1
+  ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo tar -C /etc/puppet/ -xzf /tmp/${ARTIFACT} --selinux" > /dev/null 2>&1
   [[ $? != '0' ]] && echo "Error extracting artifact on  ${PUPPET}" | output ERROR && exit 1
   ssh -o StrictHostKeyChecking=no deployment@${PUPPET} "sudo rm /tmp/${ARTIFACT}" > /dev/null 2>&1
   [[ $? != '0' ]] && echo "Error removing compressed version of artifact on  ${PUPPET}" | output ERROR && exit 1

--- a/site/profiles/manifests/puppet/master.pp
+++ b/site/profiles/manifests/puppet/master.pp
@@ -50,8 +50,7 @@ class profiles::puppet::master (
       ensure  => directory,
       owner   => puppet,
       group   => puppet,
-      mode    => '0644',
-      recurse => true
+      mode    => '0644'
     }
 
     # Install build dependancies

--- a/site/profiles/manifests/puppet/master.pp
+++ b/site/profiles/manifests/puppet/master.pp
@@ -47,10 +47,10 @@ class profiles::puppet::master (
 
     # Ensure permissions are set correctly on puppet/environments dir
     file { '/etc/puppet/environments' :
-      ensure  => directory,
-      owner   => puppet,
-      group   => puppet,
-      mode    => '0644'
+      ensure => directory,
+      owner  => puppet,
+      group  => puppet,
+      mode   => '0644'
     }
 
     # Install build dependancies


### PR DESCRIPTION
These changes should help to reduce the time required for a puppet agent run on our puppet masters by preventing puppet from controlling the environment directory and by ensuring that the correct file ownership, permissions and SE Linux attributes are set during the creation of the puppet code artefact as opposed to during the puppet agent run. 