### PR TITLE
Feature protect puppetdb

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -5,7 +5,6 @@ classes:
   - 'profiles::deployment'
   - 'profiles::ntp'
   - 'profiles::git'
-  - 'profiles::firewall'
   - 'profiles::custom_facts'
   - 'selinux'
   - 'sudo'

--- a/hiera/roles/puppet-master.yaml
+++ b/hiera/roles/puppet-master.yaml
@@ -7,3 +7,9 @@ classes:
 profiles::puppet::do_not_manage: true
 profiles::puppet::master::deployment_key: ''
 profiles::puppet::master::control_repo: 'https://github.com/LandRegistry-Ops/puppet-control.git'
+
+profiles::puppet::puppetdb_firewall::firewall_enabled: true
+profiles::puppet::puppetdb_firewall::services:
+  puppet:
+    range: 0.0.0.0/0
+    port:  8140

--- a/site/profiles/manifests/puppet/master.pp
+++ b/site/profiles/manifests/puppet/master.pp
@@ -29,6 +29,9 @@ class profiles::puppet::master (
 
     $environment = hiera( environment , 'production')
 
+    # Configure puppetdb firewall
+    include profiles::puppet::puppetdb_firewall
+
     # Install nginx
     include ::profiles::nginx
 
@@ -60,12 +63,17 @@ class profiles::puppet::master (
     }
 
     # Install required gems
-    $gems = ['rack', 'unicorn']
-    package { $gems :
+    package { 'rack' :
+      ensure   => '1.6.4', # 1.6.4 is not dependennt on specific ruby version
+      provider => gem,
+      require  => Package [ $build_dependencies, 'rubygems','ruby-devel']
+    }
+    package { 'unicorn' :
       ensure   => installed,
       provider => gem,
       require  => Package [ $build_dependencies, 'rubygems','ruby-devel']
     }
+
 
     # Copy standard puppet rack config
     file { '/etc/puppet/config.ru' :
@@ -107,7 +115,7 @@ class profiles::puppet::master (
       group   => 'root',
       source  => 'puppet:///modules/profiles/puppetmaster-unicorn.service',
       notify  => Exec ['systemctl daemon-reload'],
-      require => Package ['unicorn']
+      require => Package ['unicorn','rack']
     }
 
     # Reload systemd to pick up config change

--- a/site/profiles/manifests/puppet/puppetdb_firewall.pp
+++ b/site/profiles/manifests/puppet/puppetdb_firewall.pp
@@ -1,0 +1,67 @@
+# Class: profiles::puppet::puppetdb_firewall
+#
+# This class sets up a basic IP tables firewall to restric acccess to puppetdb
+#
+# Parameters:
+#
+#
+#
+
+#
+# Sample Usage:
+#  class { 'profiles::puppet::master':
+#    control_repo => 'https://github.com/LandRegistry-Ops/puppet-control.git',
+#  }
+#
+class profiles::puppet::puppetdb_firewall (
+
+  $firewall_enabled  = false,
+  $ssh_allowed_range = '0.0.0.0/0',
+  $services          = {}
+
+){
+
+  case $firewall_enabled {
+    true :{
+      notify {'firewall_enabled': message => 'Firewall enabled' }
+      # Disable and remove firewalld
+      service { 'firewalld':
+        ensure => stopped,
+        enable => false,
+      }
+      package { 'firewalld':
+        ensure => purged
+      }
+      # Install and enable IP tables
+      package { 'iptables-services' :
+        ensure => installed
+      }
+      service { 'iptables':
+        ensure  => running,
+        enable  => true,
+        require => Package ['iptables-services']
+      }
+      # Configure iptables rules from template
+      file { '/etc/sysconfig/iptables':
+        content => template('profiles/puppetdb_iptables.conf.erb'),
+        owner   => root,
+        group   => root,
+        mode    => '0600',
+        notify  => Service['iptables']
+      }
+    }
+    default :{
+      notify {'firewall_disabled': message => 'Firewall disabled' }
+      # Ensure that firewalld service is not running
+      service { 'firewalld':
+        ensure => stopped,
+        enable => false,
+      }
+      # Ensure that iptables is not running
+      service { 'iptables':
+        ensure => stopped,
+        enable => false,
+      }
+    }
+  }
+}

--- a/site/profiles/templates/puppetdb_iptables.conf.erb
+++ b/site/profiles/templates/puppetdb_iptables.conf.erb
@@ -1,0 +1,65 @@
+# Establish Chain policies
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:FILTER - [0:0]
+:SERVICE - [0:0]
+:SSH - [0:0]
+
+# INPUT chain rules
+-A INPUT -p icmp -m icmp --icmp-type echo-request -m limit --limit 10/min -m comment --comment "Throttle pings to 10/m" -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type echo-request -m comment --comment "Drop pings over threshold" -j DROP
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "Allow all established connections" -j ACCEPT
+-A INPUT -i lo -m comment --comment "Allow loopback traffic" -j ACCEPT
+-A INPUT -m conntrack --ctstate INVALID -m comment --comment "Drop invalid packets" -j DROP
+-A INPUT -p tcp -m conntrack --ctstate NEW -m comment --comment "Pass TCP traffic to FILTER chain" -j FILTER
+-A INPUT -p udp -m conntrack --ctstate NEW -m comment --comment "Pass UDP traffic to FILTER chain" -j FILTER
+-A INPUT -m comment --comment "Reject other protocols" -j REJECT --reject-with icmp-proto-unreachable
+#
+# In the INPUT chain we accept all related and established traffic, drop any
+# invalid packets before then passing TCP and UDP traffic off to the FILTER
+# chain. Any other protocols are rejected. We also accept icmp echos (pings)
+# but they are throttled to 10/minute.
+#
+
+# FILTER chain rules
+#-A FILTER -p tcp -m recent --update --seconds 60 --name BLACKLIST --rsource -m comment --comment "Block SYN scans" -j REJECT --reject-with tcp-rst
+#-A FILTER -p udp -m recent --update --seconds 60 --name BLACKLIST --rsource -m comment --comment "Block UDP scans" -j REJECT --reject-with icmp-port-unreachable
+-A FILTER -m comment --comment "Pass traffic to SERVICE chain to check for valid service port" -j SERVICE
+#-A FILTER -p tcp -m recent --set --name BLACKLIST -m comment --comment "Blacklist SYN scans" -j REJECT --reject-with tcp-rst
+#-A FILTER -p udp -m recent --set --name BLACKLIST -m comment --comment "Blacklist UDP scans" -j REJECT --reject-with icmp-port-unreach
+#
+# In the FILTER chain we block any data LAN connections for 60 seconds which
+# have been labelled as BLACKLIST due to hitting invalid ports. All traffic
+# which has not yet hit an invalid port is passed to the SERVICE chain to allow
+# valid connections to be established. If it is not accepted by the SERVICE
+# chain it comes back here and is labelled with BLACKLIST.
+#
+
+# SERVICE chain rules
+-A SERVICE -p tcp -m tcp --dport 22 -m comment --comment "Pass management SSH to SSH chain" -j SSH
+<% puts services.inspect -%>
+<% if !services.empty? -%>
+<% services.each_pair do |key, val| -%>
+-A SERVICE -p tcp -m tcp -s <%= val['range'] %> --dport <%= val['port'] %> -m comment --comment "Allow data <%= key %> on <%= val['port'] %>" -j ACCEPT
+<% end -%>
+<% end -%>
+
+#
+# In the SERVICE chain we accept connections to services we have opened up to
+# the network. We are passing management LAN connections to SSH on 22 to the
+# SSH chain for filtering. On the data LAN we accept service connections.
+#
+
+# SSH chain rules
+-A SSH -m recent --name BRUTEFORCE --rttl --rcheck --hitcount 3 --seconds 15 -m comment --comment "Block SSH > 3 in 15s" -j DROP
+-A SSH -m recent --name BRUTEFORCE --rttl --rcheck --hitcount 10 --seconds 900 -m comment --comment "Block SSH > 10 in 900s" -j DROP
+-A SSH -m recent --name BRUTEFORCE --set -s <%= @ssh_allowed_range -%> -m comment --comment "Allow SSH not blacklisted" -j ACCEPT
+#
+
+# In the SSH chain we allow SSH connections to pass through unhindered on their
+# first go. If the machine then tries to connect again more than 3 times in 15
+# seconds or 5 times in 15 minutes their connection is dropped.
+#
+COMMIT


### PR DESCRIPTION
This change configures a basic firewall for our puppet masters to control access to the puppet db api. Additionally it also fixes an execution order issue with the puppet master manifest and pins the rack gem to a version that is not dependant on a specific version of Ruby.