### PR TITLE
Added support for additions script in secret repos

### DIFF
--- a/site/profiles/files/artifact.sh
+++ b/site/profiles/files/artifact.sh
@@ -109,6 +109,11 @@ for environment in ${DIR}/environments/*; do
     cp -R ${TEMPDIR}/* ${environment}/${HIERA_PATH}
     if [ $? == '0' ]; then
       echo "New secrets deployed to ${envname}" | output
+      # If additions script exists in secrets repository, run that.
+      ADDITIONS_SCRIPT="${environment}/${HIERA_PATH}/additions.sh"
+      if [[ -f ${ADDITIONS_SCRIPT} ]]; then
+        bash ${ADDITIONS_SCRIPT}
+      fi
     else
       echo "ERROR - Unable to deploy secrets from ${TEMPDIR} to ${environment}" | output ERROR
       SOFTFAIL+=("${envname}")


### PR DESCRIPTION
I'd like the ability to include additional modules from internal git repositories in our builds, but I'd also like people working outside the internal network to be able to continue to test as closely as possible to the real infrastructure.

I propose that we add support for including modules specified in the puppet-secrets repos. This would us to privately build with additional modules, but publicly function without failed dependencies.

Initially I just wanted to concatenate the Puppetfile but as this is managed by R10K I can't easily get between the clone and the module installs.

Instead, later in the process when the secret repos are cloned in, the artifact generation script will look for  a script in the secret repo called 'additions.sh' where additional internal-specific actions can be carried out for setting up the build artifact.