### PR TITLE
Nginx SELinx config and WSGI batch application type

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod 'jfryman/selinux',                 '0.4.0'
 mod 'puppet-gradle',                   :git => 'https://github.com/LandRegistry-Ops/puppet-gradle.git',
                                        :ref => 'ddca379e88c07d37bc1c902f5a380412ffc5ec38'
 mod 'puppet-wsgi',                     :git => 'https://github.com/LandRegistry-Ops/puppet-wsgi.git',
-                                       :ref => '790cafc1ac7770d9263a292e203e283229633769'
+                                       :ref => 'b8b2e691cff9338310d25ec1a9098a1922ac4fc9' 
 mod 'leinaddm/htpasswd',               '0.0.3'
 mod 'maestrodev/wget',                 '1.7.3'
 mod 'openstackci/pip',                 :git => 'https://github.com/openstack-infra/puppet-pip.git',

--- a/site/profiles/files/nginx_name_connect.te
+++ b/site/profiles/files/nginx_name_connect.te
@@ -1,0 +1,13 @@
+
+module nginx_name_connect 1.0;
+
+require {
+        type httpd_t;
+        type commplex_link_port_t;
+        class tcp_socket name_connect;
+}
+
+#============= httpd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'httpd_can_network_connect'
+allow httpd_t commplex_link_port_t:tcp_socket name_connect;

--- a/site/profiles/manifests/nginx_selinux.pp
+++ b/site/profiles/manifests/nginx_selinux.pp
@@ -23,5 +23,10 @@ class profiles::nginx_selinux (
     ensure => 'present',
     source => 'puppet:///modules/profiles/nginx_unreservedport_name_connect.te'
   }
+  # Load SELinuux policy for NginX
+  selinux::module { 'nginx_name_connect':
+    ensure => 'present',
+    source => 'puppet:///modules/profiles/nginx_name_connect.te'
+  }
 
 }


### PR DESCRIPTION
1. New SELinux config to allow port 5001 via Nginx.
2. Pull in WSGI module version that includes 'batch' application type.