### PR TITLE
Remove HA policy for queues on default vhost

### DIFF
--- a/site/profiles/manifests/rabbitmq.pp
+++ b/site/profiles/manifests/rabbitmq.pp
@@ -73,15 +73,6 @@ class profiles::rabbitmq(
         require                  => Class[erlang]
       }
 
-      rabbitmq_policy { 'ha-all@/':
-        pattern    => '.*',
-        priority   => 0,
-        applyto    => 'all',
-        definition => {
-          'ha-mode'      => 'all',
-          'ha-sync-mode' => 'automatic',
-        }
-      }
     }
 
     default : {


### PR DESCRIPTION
This change removes the default high availability policy for queues on the default vhost on clustered rabbit nodes.   