### PR TITLE
Rabbitmq Changes for production

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -28,6 +28,7 @@ accounts:
    groups:
      - lr-admin
  deployment:
+   home_dir: /opt/deployment
    comment: Automated CI deployment
    ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDky5bUs3nlN78+0d+nzt2z2ZeZ4lUsiDSV2FPl3Oc0HZ2tkwM+FF++QJp8VycEoQ+fRIB9ZMksYDghJBymNG0paNH1YwjXtRz3/bfc/qtXm1BBG1s+L+9LKnncjiYHCh+9uQ65IZQ+r/eandUnGnOzVZQAgX69Qd+PlafLH/W1W6pfrRTq8sI/yyINWhXfDlSX5WuZ3hp783dt6WptyEaQdptTz74A5MG9Szp31eLL+mJl8UYWelDH/S8jzNOiLuh9sQzv9hKqHeRXZzZjk+MVAcb1UoJjNUvLA0+N26fWhqa8mSrtXHo/4wjCt1Yo2J+fU967oV3KJNbyY84kFysB
    groups:

--- a/site/profiles/manifests/rabbitmq.pp
+++ b/site/profiles/manifests/rabbitmq.pp
@@ -73,15 +73,6 @@ class profiles::rabbitmq(
         require                  => Class[erlang]
       }
 
-      rabbitmq_policy { 'ha-all@/':
-        pattern    => '.*',
-        priority   => 0,
-        applyto    => 'all',
-        definition => {
-          'ha-mode'      => 'all',
-          'ha-sync-mode' => 'automatic',
-        }
-      }
     }
 
     default : {


### PR DESCRIPTION
This change removes the default high availability policy for queues on the default vhost on clustered rabbit nodes.