### PR TITLE
removing spam from puppet debug messages

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -44,12 +44,12 @@ mod 'puppet-files',                    :git => 'https://github.com/LandRegistry-
 mod 'puppet-filebeat',                 :git => 'https://github.com/LandRegistry-Ops/puppet-filebeat.git',
                                        :ref => 'db07e248bf3c06231c673f06eed4aa8950e8ad92'
 mod 'puppet-logreceiver',              :git => 'https://github.com/LandRegistry-Ops/puppet-logreceiver.git',
-                                       :ref => '826a2ac7a243ece6876fc4cc1ea9b39df4173c48'
+                                       :ref => 'b5b95feece627a27e10af47df41b846aee939292'
 mod 'puppet-logconsumer',              :git => 'https://github.com/LandRegistry-Ops/puppet-logconsumer.git',
-                                       :ref => '577c1e51d90e8ce716c2a8d8aacff78a25e828a1'
+                                       :ref => 'e400b4cd9126060c8ba8a06a87bc6df3e45d1880'
 mod 'willdurand/nodejs',               '1.9.5'
 mod 'puppet-rabbit',                   :git => 'https://github.com/LandRegistry-Ops/puppet-rabbit.git',
-                                       :ref => '99ee2d70725b98e8d43e2645d95598327cbcf845'
+                                       :ref => 'e8572a5639523784adf72d08b5a3446bf796fb8e'
 mod 'puppet-elastic',                  :git => 'https://github.com/LandRegistry-Ops/puppet-elastic.git',
                                        :ref => '9dca154599132f220ed560d9b8efd38abae87b66'
 mod 'puppet-kibana',                   :git => 'https://github.com/LandRegistry-Ops/puppet-kibana.git',


### PR DESCRIPTION
removed all comments from logreceiver, rabbit and logconsumer to lessen the amount of spam in elastic search.