### PR TITLE
Bump puppet-firewallservice version for latest changes

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -55,7 +55,7 @@ mod 'puppet-elastic',                  :git => 'https://github.com/LandRegistry-
 mod 'puppet-kibana',                   :git => 'https://github.com/LandRegistry-Ops/puppet-kibana.git',
                                        :ref => '84d1aecbeb01eef6de616f252f372257492a974d'
 mod 'puppet-firewallservice',          :git => 'https://github.com/LandRegistry-Ops/puppet-firewallservice.git',
-                                       :ref => '0.1.1'
+                                       :ref => '0.1.5'
 # Dependency modules
 mod 'ceritsc/yum',                     '0.9.8'
 mod 'croddy/make',                     '0.0.5'


### PR DESCRIPTION
Incorporates change to default post firewall rule, documentation updates and inclusion of metadata.json file for the module.