### PR TITLE
Set default SELinux module prefix

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -63,3 +63,8 @@ if versioncmp($::puppetversion,'3.6.1') >= 0 {
   line => $::fqdn,
   tag  => 'ansible_hosts'
 }
+
+# Set SELinux module files to have no fiel name prefix
+Selinux::Module {
+  prefix => ''
+}


### PR DESCRIPTION
This change addresses the issue of SE Linux modules failing to compile when the default prefix 'local_' is added to the name of the compiled module.