### PR TITLE
Increased WSGI module version from 1.2.1 to 1.3.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod 'jfryman/selinux',                 '0.4.0'
 mod 'puppet-gradle',                   :git => 'https://github.com/LandRegistry-Ops/puppet-gradle.git',
                                        :ref => '8aec2ee291a34e79531a0045a7c0027aaa8138d8'
 mod 'puppet-wsgi',                     :git => 'https://github.com/LandRegistry-Ops/puppet-wsgi.git',
-                                       :ref => '1.2.1'
+                                       :ref => '1.3.0'
 mod 'leinaddm/htpasswd',               '0.0.3'
 mod 'maestrodev/wget',                 '1.7.3'
 mod 'openstackci/pip',                 :git => 'https://github.com/openstack-infra/puppet-pip.git',


### PR DESCRIPTION
This change introduces a later version of the LandRegistry/WSGI module which brings changes from [1.2.2](https://github.com/LandRegistry-Ops/puppet-wsgi/releases/tag/1.2.2) and [1.3.0](https://github.com/LandRegistry-Ops/puppet-wsgi/releases/tag/1.3.0).

The most significant change is the move from `lr-python3` to `python34u` (from [IUS](https://ius.io/)) which removes the need to maintain `lr-python3` and allows us to move forward to Python version 3.4.5.

It is worth noting however that `site/profiles/appserver.pp` still requires the use of `lr-python3` although this profile is deprecated and should not be used anywhere new.