### PR TITLE
Increased landregistry/wsgi version to 1.3.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod 'jfryman/selinux',                 '0.4.0'
 mod 'puppet-gradle',                   :git => 'https://github.com/LandRegistry-Ops/puppet-gradle.git',
                                        :ref => '8aec2ee291a34e79531a0045a7c0027aaa8138d8'
 mod 'puppet-wsgi',                     :git => 'https://github.com/LandRegistry-Ops/puppet-wsgi.git',
-                                       :ref => '1.2.1'
+                                       :ref => '1.3.1'
 mod 'leinaddm/htpasswd',               '0.0.3'
 mod 'maestrodev/wget',                 '1.7.3'
 mod 'openstackci/pip',                 :git => 'https://github.com/openstack-infra/puppet-pip.git',


### PR DESCRIPTION
See https://github.com/LandRegistry-Ops/puppet-wsgi/releases/tag/1.3.1