### PR TITLE
Feature/automatic dns

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -61,7 +61,7 @@ mod 'puppet-nagios',                   :git => 'https://github.com/LandRegistry-
 mod 'puppet-nagiosclient',             :git => 'https://github.com/LandRegistry-Ops/puppet-nagiosclient.git',
                                        :ref => '0.10.1'
 mod 'landregistry/powerdns',           :git => 'https://github.com/LandRegistry-Ops/puppet-powerdns.git',
-                                       :ref => '0.1.0'
+                                       :ref => '0.2.0'
 # Dependency modules
 mod 'ceritsc/yum',                     '0.9.8'
 mod 'croddy/make',                     '0.0.5'

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -7,6 +7,9 @@ notify{"Application Environment: ${::application_environment}": loglevel => debu
 # Include classes specified in Hiera
 hiera_include('classes')
 
+# Include automagical DNS
+include ::profiles::dns
+
 # Create 'lr-admin' group on all hosts
 group { 'lr-admin' :
   ensure => present,

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -32,24 +32,24 @@ class profiles::dns (
 
   if (has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone')) {
     $eth0 = $interfaces['eth0']
-    $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
+    $eth0_hostname = "${eth0['prepend']}${::hostname}${eth0['append']}"
     powerdns::record { $eth0_hostname :
-      ensure   => present,
-      type     => 'A',
-      ttl      => '3600',
-      zone     => $eth0['zone'],
-      content  => [ $::ipaddress_eth0 ]
+      ensure  => present,
+      type    => 'A',
+      ttl     => '3600',
+      zone    => $eth0['zone'],
+      content => [ $::ipaddress_eth0 ]
     }
   }
 
   if (has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone')) {
-    $eth1_hostname = "${interfaces['eth1']['prepend']}${hostname}${interfaces['eth1']['append']}"
+    $eth1_hostname = "${interfaces['eth1']['prepend']}${::hostname}${interfaces['eth1']['append']}"
     powerdns::record { $eth1_hostname :
-      ensure   => present,
-      type     => 'A',
-      ttl      => '3600',
-      zone     => $interfaces['eth1']['zone'],
-      content  => [ $::ipaddress_eth1 ]
+      ensure  => present,
+      type    => 'A',
+      ttl     => '3600',
+      zone    => $interfaces['eth1']['zone'],
+      content => [ $::ipaddress_eth1 ]
     }
   }
 

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -30,7 +30,7 @@ class profiles::dns (
 
   include ::stdlib
 
-  if has_key($interfaces, 'eth0') {
+  if (has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone'))
     $eth0 = $interfaces['eth0']
     $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
     powerdns::record { $eth0_hostname :
@@ -42,7 +42,7 @@ class profiles::dns (
     }
   }
 
-  if has_key($interfaces, 'eth1') {
+  if (has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone'))
     $eth1_hostname = "${interfaces['eth1']['prepend']}${hostname}${interfaces['eth1']['append']}"
     powerdns::record { $eth1_hostname :
       ensure   => present,

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -1,0 +1,56 @@
+# Class profiles::dns
+#
+# This class will manage DNS records for servers and supports multiple interfaces
+#
+# Requires:
+# - puppetlabs/stdlib
+# - landregistry/powerdns
+#
+# Sample Usage:
+#   class { 'profiles::dns':
+#     interfaces => {
+#       eth0 => {
+#         prepend => '',
+#         append  => '-mgmt',
+#         zone    => 'host.dev.ctp.local'
+#       },
+#       eth1 => {
+#         prepend => '',
+#         append  => '',
+#         zone    => 'host.dev.ctp.local'
+#       }
+#     }
+#   }
+#
+class profiles::dns (
+
+  $interfaces = hiera_hash('interfaces',undef)
+
+){
+
+  include ::stdlib
+
+  if has_key($interfaces, 'eth0') {
+    $eth0 = $interfaces['eth0']
+    $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
+    powerdns::record { $eth0_hostname :
+      ensure   => present,
+      type     => 'A',
+      ttl      => '3600',
+      zone     => $eth0['zone'],
+      content  => [ $::ipaddress_eth0 ]
+    }
+  }
+
+  if has_key($interfaces, 'eth1') {
+    $eth1_hostname = "${interfaces['eth1']['prepend']}${hostname}${interfaces['eth1']['append']}"
+    powerdns::record { $eth1_hostname :
+      ensure   => present,
+      type     => 'A',
+      ttl      => '3600',
+      zone     => $interfaces['eth1']['zone'],
+      content  => [ $::ipaddress_eth1 ]
+    }
+  }
+
+}

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -1,3 +1,27 @@
+# Class profiles::dns
+#
+# This class will manage DNS records for servers and supports multiple interfaces
+#
+# Requires:
+# - puppetlabs/stdlib
+# - landregistry/powerdns
+#
+# Sample Usage:
+#   class { 'profiles::dns':
+#     interfaces => {
+#       eth0 => {
+#         prepend => '',
+#         append  => '-mgmt',
+#         zone    => 'host.dev.ctp.local'
+#       },
+#       eth1 => {
+#         prepend => '',
+#         append  => '',
+#         zone    => 'host.dev.ctp.local'
+#       }
+#     }
+#   }
+#
 class profiles::dns (
 
   $interfaces = hiera_hash('interfaces',undef)
@@ -6,41 +30,27 @@ class profiles::dns (
 
   include ::stdlib
 
-  # Schema:
-  # $interfaces = {
-  #   eth0 => {
-  #     prepend => '',
-  #     append  => '-mgmt',
-  #     zone    => 'host.dev.ctp.local'
-  #   },
-  #   eth1 => {
-  #     prepend => '',
-  #     append  => '',
-  #     zone    => 'host.dev.ctp.local'
-  #   }
-  # }
-
   if ($::ipaddress_eth0 and has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone')) {
     $eth0 = $interfaces['eth0']
-    $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
+    $eth0_hostname = "${eth0['prepend']}${::hostname}${eth0['append']}"
     powerdns::record { $eth0_hostname :
-      ensure   => present,
-      type     => 'A',
-      ttl      => '3600',
-      zone     => $eth0['zone'],
-      content  => [ $::ipaddress_eth0 ]
+      ensure  => present,
+      type    => 'A',
+      ttl     => '3600',
+      zone    => $eth0['zone'],
+      content => [ $::ipaddress_eth0 ]
     }
   }
 
   if ($::ipaddress_eth1 and has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone')) {
     $eth1 = $interfaces['eth1']
-    $eth1_hostname = "${eth1['prepend']}${hostname}${eth1['append']}"
+    $eth1_hostname = "${eth1['prepend']}${::hostname}${eth1['append']}"
     powerdns::record { $eth1_hostname :
-      ensure   => present,
-      type     => 'A',
-      ttl      => '3600',
-      zone     => $eth1 ['zone'],
-      content  => [ $::ipaddress_eth1 ]
+      ensure  => present,
+      type    => 'A',
+      ttl     => '3600',
+      zone    => $eth1 ['zone'],
+      content => [ $::ipaddress_eth1 ]
     }
   }
 

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -30,7 +30,7 @@ class profiles::dns (
 
   include ::stdlib
 
-  if (has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone'))
+  if (has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone')) {
     $eth0 = $interfaces['eth0']
     $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
     powerdns::record { $eth0_hostname :
@@ -42,7 +42,7 @@ class profiles::dns (
     }
   }
 
-  if (has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone'))
+  if (has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone')) {
     $eth1_hostname = "${interfaces['eth1']['prepend']}${hostname}${interfaces['eth1']['append']}"
     powerdns::record { $eth1_hostname :
       ensure   => present,

--- a/site/profiles/manifests/dns.pp
+++ b/site/profiles/manifests/dns.pp
@@ -1,27 +1,3 @@
-# Class profiles::dns
-#
-# This class will manage DNS records for servers and supports multiple interfaces
-#
-# Requires:
-# - puppetlabs/stdlib
-# - landregistry/powerdns
-#
-# Sample Usage:
-#   class { 'profiles::dns':
-#     interfaces => {
-#       eth0 => {
-#         prepend => '',
-#         append  => '-mgmt',
-#         zone    => 'host.dev.ctp.local'
-#       },
-#       eth1 => {
-#         prepend => '',
-#         append  => '',
-#         zone    => 'host.dev.ctp.local'
-#       }
-#     }
-#   }
-#
 class profiles::dns (
 
   $interfaces = hiera_hash('interfaces',undef)
@@ -30,26 +6,41 @@ class profiles::dns (
 
   include ::stdlib
 
-  if (has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone')) {
+  # Schema:
+  # $interfaces = {
+  #   eth0 => {
+  #     prepend => '',
+  #     append  => '-mgmt',
+  #     zone    => 'host.dev.ctp.local'
+  #   },
+  #   eth1 => {
+  #     prepend => '',
+  #     append  => '',
+  #     zone    => 'host.dev.ctp.local'
+  #   }
+  # }
+
+  if ($::ipaddress_eth0 and has_key($interfaces, 'eth0') and has_key($interfaces['eth0'], 'zone')) {
     $eth0 = $interfaces['eth0']
-    $eth0_hostname = "${eth0['prepend']}${::hostname}${eth0['append']}"
+    $eth0_hostname = "${eth0['prepend']}${hostname}${eth0['append']}"
     powerdns::record { $eth0_hostname :
-      ensure  => present,
-      type    => 'A',
-      ttl     => '3600',
-      zone    => $eth0['zone'],
-      content => [ $::ipaddress_eth0 ]
+      ensure   => present,
+      type     => 'A',
+      ttl      => '3600',
+      zone     => $eth0['zone'],
+      content  => [ $::ipaddress_eth0 ]
     }
   }
 
-  if (has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone')) {
-    $eth1_hostname = "${interfaces['eth1']['prepend']}${::hostname}${interfaces['eth1']['append']}"
+  if ($::ipaddress_eth1 and has_key($interfaces, 'eth1') and has_key($interfaces['eth1'], 'zone')) {
+    $eth1 = $interfaces['eth1']
+    $eth1_hostname = "${eth1['prepend']}${hostname}${eth1['append']}"
     powerdns::record { $eth1_hostname :
-      ensure  => present,
-      type    => 'A',
-      ttl     => '3600',
-      zone    => $interfaces['eth1']['zone'],
-      content => [ $::ipaddress_eth1 ]
+      ensure   => present,
+      type     => 'A',
+      ttl      => '3600',
+      zone     => $eth1 ['zone'],
+      content  => [ $::ipaddress_eth1 ]
     }
   }
 


### PR DESCRIPTION
Using the new features in the [landregistry/powerdns](https://github.com/LandRegistry-Ops/puppet-powerdns) module [introduced in version 0.2.0](https://github.com/LandRegistry-Ops/puppet-powerdns/releases/tag/0.2.0) I've created a new profile which allows for extremely easy DNS record creation, with support for different hostname variants on different interfaces.

It requires a hash called `interfaces` to be created in the Hiera tree in order to create DNS records. It also requires the PowerDNS API hash to be configured correctly to connect to the PowerDNS API.

```yaml
interfaces:
    eth0:
        zone: host.dev.ctp.local
    eth1:
        append: '-mgmt'
        zone: host.dev.ctp.local
```

I have intentionally chosen to use such a generic hash name so that other things (such as Nagios) can also store information regarding interfaces in the same tree.