### PR TITLE
Enhancement/haproxy

### DIFF
--- a/site/ha/templates/haproxy.conf.erb
+++ b/site/ha/templates/haproxy.conf.erb
@@ -33,8 +33,10 @@ listen <%= name %> *:<%= config['port'] %>
     option httpchk GET <%= config['healthcheck'] %>
 <% config['backends'].each do |backend| -%>
 <% if config.key?('healthcheck_port') -%>
+    # Backend <%= backend %> with healthcheck at <%= backend.split(':')[0] %>:<%= config['healthcheck_port'] %>
     server <%= backend.split(':')[0] %> <%= backend %> check port <%= config['healthcheck_port'] %>
 <% else -%>
+    # Backend <%= backend %> with native healthcheck
     server <%= backend.split(':')[0] %> <%= backend %> check
 <% end -%>
 <% end -%>

--- a/site/ha/templates/haproxy.conf.erb
+++ b/site/ha/templates/haproxy.conf.erb
@@ -30,9 +30,13 @@ listen <%= name %> *:<%= config['port'] %>
 <% end -%>
 
 <% else -%>
-    option httpchk GET <%=config['healthcheck'] %>
+    option httpchk GET <%= config['healthcheck'] %>
 <% config['backends'].each do |backend| -%>
+<% if config.key?('healthcheck_port') -%>
+    server <%= backend.split(':')[0] %> <%= backend %> check port <%= config['healthcheck_port'] %>
+<% else -%>
     server <%= backend.split(':')[0] %> <%= backend %> check
+<% end -%>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
When deploying applications using the Java framework Springboot it's possible that the applications have a secondary port used for management actions and healthchecks.

Previously the only healthchecks we supported were `HTTP GET` requests against the application port. HAProxy also supports [performing healthchecks against a different port](https://www.haproxy.com/doc/aloha/7.0/haproxy/healthchecks.html) so I've added an expression to check if `healthcheck_port` is set and if so set the value as the healthcheck port.