### PR TITLE
Amend HA class to allow use of other load balancers

### DIFF
--- a/site/ha/manifests/init.pp
+++ b/site/ha/manifests/init.pp
@@ -1,5 +1,5 @@
 #
-# Hash example:
+# Hash example using HAProxy:
 # class { 'ha':
 #   virtual_ip   => '192.168.99.10',
 #   interface    => 'eth1',
@@ -16,19 +16,59 @@
 #     }
 #   }
 #  }
+#
+# Hiera example using HAProxy:
+#
+# ha::interface: eth1
+# ha::virtual_ip: 192.168.99.10
+# ha::lb_instances:
+#   default:
+#     port: 80
+#     healthcheck: /
+#     backends:
+#       - localhost:8080
+#       - localhost:8081
+#   test:
+#     port: 9000
+#     healthcheck: /health
+#     backends:
+#       - airbnb.com
+#
+# Hiera example using nginx:
+#
+# ha::interface: eth1
+# ha::virtual_ip: 192.168.99.10
+# ha:: use_haproxy: false
+# ha::track_script_name: 'chk_nginx'
+# ha::track_script_cmd: 'pidof nginx'
+#
+
 class ha (
   $lb_instances = undef,
   $interface   = 'eth0',
   $virtual_ip  = undef,
   $sticky      = false,
   $auth_users  = undef,
+  $use_haproxy = true,
+  $track_script_name = 'haproxy',
+  $track_script_cmd = 'pgrep haproxy',
 ) {
 
   include stdlib
+
+  # If we're using haproxy then lb_instances hash must be supplied
+  if $use_haproxy {
   validate_hash($lb_instances)
+  }
   validate_string($interface)
   validate_string($virtual_ip)
   validate_bool($sticky)
+  if $auth_users != undef {
+  validate_hash($auth_users)
+  }
+  validate_bool($use_haproxy)
+  validate_string($track_script_name)
+  validate_string($track_script_cmd)
 
   unless has_interface_with($interface) {
     fail("${interface} is not a valid network port")
@@ -37,28 +77,11 @@ class ha (
     fail("${virtual_ip} is not a valid IP address")
   }
 
-  $haproxy_cfg    = '/etc/haproxy/haproxy.cfg'
+  # Install and configure keepalived
   $keepalived_cfg = '/etc/keepalived/keepalived.conf'
   $vip_priority   = fqdn_rand_string(2,'0123456789')
 
-  ensure_packages(['haproxy','keepalived'])
-
-  file { $haproxy_cfg :
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('ha/haproxy.conf.erb'),
-    require => Package['haproxy'],
-    notify  => Service['haproxy']
-  }
-
-  service { 'haproxy':
-    ensure    => running,
-    enable    => true,
-    require   => Package['haproxy'],
-    subscribe => File[$haproxy_cfg]
-  }
+  ensure_packages('keepalived')
 
   file { $keepalived_cfg :
     ensure  => present,
@@ -70,16 +93,42 @@ class ha (
     notify  => Service['keepalived']
   }
 
-  selboolean { 'haproxy_connect_any' :
-    value      => 'on',
-    persistent => true,
-  }
-
   service { 'keepalived':
     ensure    => running,
     enable    => true,
-    require   => [ Package['keepalived'], Selboolean['haproxy_connect_any'] ],
+    require   => Package['keepalived'],
     subscribe => File[$keepalived_cfg]
+  }
+
+  # If we're using HA Proxy to do the load balancing (default behaviour) then this
+  # section applies
+  if ($use_haproxy) {
+
+    ensure_packages('haproxy')
+    $haproxy_cfg    = '/etc/haproxy/haproxy.cfg'
+
+    file { $haproxy_cfg :
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('ha/haproxy.conf.erb'),
+      require => Package['haproxy'],
+      notify  => Service['haproxy']
+    }
+
+    service { 'haproxy':
+      ensure    => running,
+      enable    => true,
+      require   => [ Package['haproxy'], Selboolean['haproxy_connect_any'] ],
+      subscribe => File[$haproxy_cfg]
+    }
+
+    selboolean { 'haproxy_connect_any' :
+      value      => 'on',
+      persistent => true,
+    }
+
   }
 
 }

--- a/site/ha/templates/keepalived.conf.erb
+++ b/site/ha/templates/keepalived.conf.erb
@@ -1,5 +1,5 @@
-vrrp_script haproxy {
-  script "pgrep haproxy"
+vrrp_script <%= @track_script_name %> {
+  script "<%= @track_script_cmd %>"
   interval 1
   wait 1
 }
@@ -13,6 +13,6 @@ vrrp_instance <%= @fqdn %> {
         <%= @virtual_ip %>
     }
     track_script {
-      haproxy
+      <%= @track_script_name %>
     }
 }


### PR DESCRIPTION
This PR allows you to use load balancers for HA other than HAProxy. Keepalived will always be deployed to manage the VIP. 

Summary of changes

- 3 new parameters with defaults so as to not break existing deployments ($use_haproxy = true, $track_script_name = 'haproxy', $track_script_cmd = 'pgrep haproxy')
- Updated validators
- keepalived.conf template now uses $track_script_name and $track_script_cmd
- Moved 'haproxy' config into its own if block
- Updated examples
