### PR TITLE
new gitlab.pp for s3 and nfs backups

### DIFF
--- a/site/profiles/manifests/gitlab.pp
+++ b/site/profiles/manifests/gitlab.pp
@@ -29,7 +29,8 @@ class profiles::gitlab (
   $ldap_bind_dn     = 'undef',
   $ldap_password    = 'undef',
   $aws_acccess_key  = undef,
-  $aws_secret_key   = undef
+  $aws_secret_key   = undef,
+  $backup_method    = undef
 
 ){
 
@@ -101,7 +102,7 @@ class profiles::gitlab (
     }
 
     #Set up s3 backups if on AWS
-    if $::hosting_platform == AWS {
+    if $backup_method == 's3' {
 
       package { 's3cmd':
         ensure => present,
@@ -116,7 +117,7 @@ class profiles::gitlab (
     }
 
     #Set up nfs mount for internal backups
-    if $::hosting_platform == 'internal' {
+    if $backup_method == 'nfs' {
 
       package { 'nfs-utils' :
         ensure => present


### PR DESCRIPTION
allowing for machines that do not have the hosting_platform of internal or aws to be configured for NFS or S3 backups.