### PR TITLE
Enhancement/lr readonly

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -16,7 +16,9 @@ group { 'lr-admin' :
   gid    => 2000
 }
 
-# Configure passwor sudo + not tty for deployment
+# Create 'lr-readonly' group on all hosts
+
+# Configure password sudo + not tty for deployment
 sudo::conf { 'deployment' :
   priority => 10,
   content  => 'Defaults: %deployment !requiretty

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -17,6 +17,7 @@ group { 'lr-admin' :
 }
 
 # Create 'lr-readonly' group on all hosts
+group { 'lr-readonly' : ensure => present }
 
 # Configure password sudo + not tty for deployment
 sudo::conf { 'deployment' :


### PR DESCRIPTION
I'd like to add an additional group for users to be placed in as their primary group. This group, 'lr-readonly' is designed to represent users that are not granted the permissions given by lr-admin.