### PR TITLE
Add openresty and associated monitoring profiles

### DIFF
--- a/site/profiles/manifests/openresty.pp
+++ b/site/profiles/manifests/openresty.pp
@@ -1,0 +1,22 @@
+# Class profiles::openresty
+#
+# This class will manage openresty installations
+#
+# Parameters:
+#  ['monitoring'] - Boolean to determine if the openresty_monitoring profile should be included. Defaults to true.
+#
+# Requires:
+# - openresty
+#
+class profiles::openresty(
+
+  $monitoring = true
+
+  ){
+
+  if $monitoring {
+    include profiles::openresty_monitoring
+  }
+
+  include openresty
+}

--- a/site/profiles/manifests/openresty_monitoring.pp
+++ b/site/profiles/manifests/openresty_monitoring.pp
@@ -1,0 +1,10 @@
+# Class profiles::openresty_monitoring
+#
+# This class will set up nagios checks for openresty installations
+#
+class profiles::openresty_monitoring(){
+  class { 'profiles::generic_monitoring':
+    monitor_service => 'nginx',
+    monitor_port    => hiera('llc_openresty_listen_port'),
+  }
+}


### PR DESCRIPTION
Adds nagios checks for an `nginx` service and the port openresty is using.