### PR TITLE
Update generic monitoring profile and add puppet master checks

### DIFF
--- a/site/profiles/manifests/generic_monitoring.pp
+++ b/site/profiles/manifests/generic_monitoring.pp
@@ -3,10 +3,10 @@
 # This class will monitor a service and port as defined in the parameters provided.
 #
 # Parameters:
-#   monitor_service            - the name of the service to look for, passed to the nagios
+#   monitor_service            - the name of the process to check for, passed to the nagios
 #                                check_service_procs command
-#   monitor_port               - the port to check for, passed to the nagios
-#                                check_service_tcp command
+#   monitor_port               - the port(s) to check for, passed to the nagios check_service_tcp
+#                                command. Supports a single value or an array.
 #   min_process_warning_count  - generate a warning alert if the number of processes
 #                                falls below this number
 #   max_process_warning_count  - generate a warning alert if the number of processes
@@ -48,10 +48,11 @@ class profiles::generic_monitoring(
     }
   }
 
-  if $monitor_port {
+  # Define resource to allow multiple port checks to be added. Port passed in as 'title' variable.
+  define create_port_check {
     @@nagios_service { "${::hostname}-lr-${name}-tcp_check" :
       ensure                => present,
-      check_command         => "check_nrpe!check_service_tcp\\!'127.0.0.1'\\!'${monitor_port}'",
+      check_command         => "check_nrpe!check_service_tcp\\!'127.0.0.1'\\!'${title}'",
       mode                  => '0644',
       owner                 => root,
       use                   => 'generic-service',
@@ -61,7 +62,11 @@ class profiles::generic_monitoring(
       notification_interval => 0,
       notifications_enabled => 1,
       notification_period   => $time_period,
-      service_description   => "LR tcp port ${monitor_port}"
+      service_description   => "LR tcp port ${title}"
     }
+  }
+
+  if $monitor_port {
+    create_port_check { $monitor_port: }
   }
 }

--- a/site/profiles/manifests/generic_monitoring.pp
+++ b/site/profiles/manifests/generic_monitoring.pp
@@ -7,6 +7,8 @@
 #                                check_service_procs command
 #   monitor_port               - the port(s) to check for, passed to the nagios check_service_tcp
 #                                command. Supports a single value or an array.
+#   monitor_ntp                - if true, a check for a ntp will be created.
+#
 #   min_process_warning_count  - generate a warning alert if the number of processes
 #                                falls below this number
 #   max_process_warning_count  - generate a warning alert if the number of processes
@@ -22,6 +24,7 @@ class profiles::generic_monitoring(
 
   $monitor_service            = false,
   $monitor_port               = false,
+  $monitor_ntp                = false,
   $min_process_warning_count  = 1,
   $max_process_warning_count  = 10,
   $min_process_critical_count = 1,
@@ -68,5 +71,22 @@ class profiles::generic_monitoring(
 
   if $monitor_port {
     create_port_check { $monitor_port: }
+  }
+
+  if $monitor_ntp {
+    @@nagios_service { "${::hostname}-lr-${name}-ntp_check" :
+      ensure                => present,
+      check_command         => "check_nrpe!check_service_ntp\\!'127.0.0.1'",
+      mode                  => '0644',
+      owner                 => root,
+      use                   => 'generic-service',
+      host_name             => $::hostname,
+      check_period          => $time_period,
+      contact_groups        => 'admins',
+      notification_interval => 0,
+      notifications_enabled => 1,
+      notification_period   => $time_period,
+      service_description   => 'LR ntp check'
+    }
   }
 }

--- a/site/profiles/manifests/puppet/master_monitoring.pp
+++ b/site/profiles/manifests/puppet/master_monitoring.pp
@@ -1,0 +1,11 @@
+# Class profiles::puppet::master_monitoring
+#
+# This class will set up nagios checks for puppet master installations
+#
+class profiles::puppet::master_monitoring(){
+  class { 'profiles::generic_monitoring':
+    monitor_service           => 'puppet',
+    monitor_port              => '8140',
+    max_process_warning_count => '30',
+  }
+}


### PR DESCRIPTION
- Updated the generic_monitoring profile to support multiple port checks and ntp checks
- Added a monitoring profile for puppet master
- Fixed puppet-lint warnings. See [here](https://puppet.com/docs/puppet/5.3/style_guide.html#chaining-arrow-syntax) for more.